### PR TITLE
Add dashboard and task features

### DIFF
--- a/app.py
+++ b/app.py
@@ -86,9 +86,27 @@ class QuoteLineItem(db.Model):
     quote = db.relationship("Quote", backref=db.backref("line_items", lazy=True))
     product = db.relationship("Product")
 
+
+class Task(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    description = db.Column(db.String(255))
+    due_date = db.Column(db.String(50))
+    model = db.Column(db.String(50))
+    record_id = db.Column(db.Integer)
+
 @app.route("/")
-def hello_world():
-    return render_template("index.html", title="Hello")
+def dashboard():
+    counts = {
+        "customers": Customer.query.count(),
+        "leads": Lead.query.count(),
+        "accounts": Account.query.count(),
+        "contacts": Contact.query.count(),
+        "deals": Deal.query.count(),
+        "products": Product.query.count(),
+        "pricebooks": Pricebook.query.count(),
+        "quotes": Quote.query.count(),
+    }
+    return render_template("dashboard.html", counts=counts, title="Dashboard")
 
 
 @app.route("/customers")
@@ -112,6 +130,37 @@ def create_customer():
     db.session.add(customer)
     db.session.commit()
     return redirect(url_for("list_customers"))
+
+
+@app.route("/customers/<int:customer_id>")
+def show_customer(customer_id):
+    customer = Customer.query.get_or_404(customer_id)
+    tasks = Task.query.filter_by(model="customers", record_id=customer_id).all()
+    return render_template(
+        "customer_detail.html",
+        customer=customer,
+        tasks=tasks,
+        title="Customer Detail",
+    )
+
+
+@app.route("/customers/<int:customer_id>/edit")
+def edit_customer(customer_id):
+    customer = Customer.query.get_or_404(customer_id)
+    return render_template(
+        "edit_customer.html", customer=customer, title="Edit Customer"
+    )
+
+
+@app.route("/customers/<int:customer_id>/update", methods=["POST"])
+def update_customer(customer_id):
+    customer = Customer.query.get_or_404(customer_id)
+    customer.name = request.form["name"]
+    customer.email = request.form.get("email")
+    customer.phone = request.form.get("phone")
+    customer.notes = request.form.get("notes")
+    db.session.commit()
+    return redirect(url_for("show_customer", customer_id=customer.id))
 
 
 @app.route("/leads")
@@ -138,6 +187,32 @@ def create_lead():
     return redirect(url_for("list_leads"))
 
 
+@app.route("/leads/<int:lead_id>")
+def show_lead(lead_id):
+    lead = Lead.query.get_or_404(lead_id)
+    tasks = Task.query.filter_by(model="leads", record_id=lead_id).all()
+    return render_template(
+        "lead_detail.html", lead=lead, tasks=tasks, title="Lead Detail"
+    )
+
+
+@app.route("/leads/<int:lead_id>/edit")
+def edit_lead(lead_id):
+    lead = Lead.query.get_or_404(lead_id)
+    return render_template("edit_lead.html", lead=lead, title="Edit Lead")
+
+
+@app.route("/leads/<int:lead_id>/update", methods=["POST"])
+def update_lead(lead_id):
+    lead = Lead.query.get_or_404(lead_id)
+    lead.name = request.form["name"]
+    lead.email = request.form.get("email")
+    lead.phone = request.form.get("phone")
+    lead.status = request.form.get("status")
+    db.session.commit()
+    return redirect(url_for("show_lead", lead_id=lead.id))
+
+
 @app.route("/accounts")
 def list_accounts():
     accounts = Account.query.all()
@@ -158,6 +233,32 @@ def create_account():
     db.session.add(account)
     db.session.commit()
     return redirect(url_for("list_accounts"))
+
+
+@app.route("/accounts/<int:account_id>")
+def show_account(account_id):
+    account = Account.query.get_or_404(account_id)
+    tasks = Task.query.filter_by(model="accounts", record_id=account_id).all()
+    return render_template(
+        "account_detail.html", account=account, tasks=tasks, title="Account Detail"
+    )
+
+
+@app.route("/accounts/<int:account_id>/edit")
+def edit_account(account_id):
+    account = Account.query.get_or_404(account_id)
+    return render_template(
+        "edit_account.html", account=account, title="Edit Account"
+    )
+
+
+@app.route("/accounts/<int:account_id>/update", methods=["POST"])
+def update_account(account_id):
+    account = Account.query.get_or_404(account_id)
+    account.name = request.form["name"]
+    account.industry = request.form.get("industry")
+    db.session.commit()
+    return redirect(url_for("show_account", account_id=account.id))
 
 
 @app.route("/contacts")
@@ -185,6 +286,35 @@ def create_contact():
     return redirect(url_for("list_contacts"))
 
 
+@app.route("/contacts/<int:contact_id>")
+def show_contact(contact_id):
+    contact = Contact.query.get_or_404(contact_id)
+    tasks = Task.query.filter_by(model="contacts", record_id=contact_id).all()
+    return render_template(
+        "contact_detail.html", contact=contact, tasks=tasks, title="Contact Detail"
+    )
+
+
+@app.route("/contacts/<int:contact_id>/edit")
+def edit_contact(contact_id):
+    contact = Contact.query.get_or_404(contact_id)
+    accounts = Account.query.all()
+    return render_template(
+        "edit_contact.html", contact=contact, accounts=accounts, title="Edit Contact"
+    )
+
+
+@app.route("/contacts/<int:contact_id>/update", methods=["POST"])
+def update_contact(contact_id):
+    contact = Contact.query.get_or_404(contact_id)
+    contact.name = request.form["name"]
+    contact.email = request.form.get("email")
+    contact.phone = request.form.get("phone")
+    contact.account_id = request.form.get("account_id") or None
+    db.session.commit()
+    return redirect(url_for("show_contact", contact_id=contact.id))
+
+
 @app.route("/deals")
 def list_deals():
     deals = Deal.query.all()
@@ -210,6 +340,33 @@ def create_deal():
     return redirect(url_for("list_deals"))
 
 
+@app.route("/deals/<int:deal_id>")
+def show_deal(deal_id):
+    deal = Deal.query.get_or_404(deal_id)
+    tasks = Task.query.filter_by(model="deals", record_id=deal_id).all()
+    return render_template(
+        "deal_detail.html", deal=deal, tasks=tasks, title="Deal Detail"
+    )
+
+
+@app.route("/deals/<int:deal_id>/edit")
+def edit_deal(deal_id):
+    deal = Deal.query.get_or_404(deal_id)
+    accounts = Account.query.all()
+    return render_template("edit_deal.html", deal=deal, accounts=accounts, title="Edit Deal")
+
+
+@app.route("/deals/<int:deal_id>/update", methods=["POST"])
+def update_deal(deal_id):
+    deal = Deal.query.get_or_404(deal_id)
+    deal.name = request.form["name"]
+    deal.amount = request.form.get("amount")
+    deal.stage = request.form.get("stage")
+    deal.account_id = request.form.get("account_id") or None
+    db.session.commit()
+    return redirect(url_for("show_deal", deal_id=deal.id))
+
+
 @app.route("/products")
 def list_products():
     products = Product.query.all()
@@ -232,6 +389,32 @@ def create_product():
     return redirect(url_for("list_products"))
 
 
+@app.route("/products/<int:product_id>")
+def show_product(product_id):
+    product = Product.query.get_or_404(product_id)
+    tasks = Task.query.filter_by(model="products", record_id=product_id).all()
+    return render_template(
+        "product_detail.html", product=product, tasks=tasks, title="Product Detail"
+    )
+
+
+@app.route("/products/<int:product_id>/edit")
+def edit_product(product_id):
+    product = Product.query.get_or_404(product_id)
+    return render_template(
+        "edit_product.html", product=product, title="Edit Product"
+    )
+
+
+@app.route("/products/<int:product_id>/update", methods=["POST"])
+def update_product(product_id):
+    product = Product.query.get_or_404(product_id)
+    product.name = request.form["name"]
+    product.price = request.form.get("price")
+    db.session.commit()
+    return redirect(url_for("show_product", product_id=product.id))
+
+
 @app.route("/pricebooks")
 def list_pricebooks():
     pricebooks = Pricebook.query.all()
@@ -249,6 +432,34 @@ def create_pricebook():
     db.session.add(pricebook)
     db.session.commit()
     return redirect(url_for("list_pricebooks"))
+
+
+@app.route("/pricebooks/<int:pricebook_id>")
+def show_pricebook(pricebook_id):
+    pricebook = Pricebook.query.get_or_404(pricebook_id)
+    tasks = Task.query.filter_by(model="pricebooks", record_id=pricebook_id).all()
+    return render_template(
+        "pricebook_detail.html",
+        pricebook=pricebook,
+        tasks=tasks,
+        title="Pricebook Detail",
+    )
+
+
+@app.route("/pricebooks/<int:pricebook_id>/edit")
+def edit_pricebook(pricebook_id):
+    pricebook = Pricebook.query.get_or_404(pricebook_id)
+    return render_template(
+        "edit_pricebook.html", pricebook=pricebook, title="Edit Pricebook"
+    )
+
+
+@app.route("/pricebooks/<int:pricebook_id>/update", methods=["POST"])
+def update_pricebook(pricebook_id):
+    pricebook = Pricebook.query.get_or_404(pricebook_id)
+    pricebook.name = request.form["name"]
+    db.session.commit()
+    return redirect(url_for("show_pricebook", pricebook_id=pricebook.id))
 
 
 @app.route("/pricebook_entries")
@@ -283,6 +494,42 @@ def create_pricebook_entry():
     return redirect(url_for("list_pricebook_entries"))
 
 
+@app.route("/pricebook_entries/<int:entry_id>")
+def show_pricebook_entry(entry_id):
+    entry = PriceBookEntry.query.get_or_404(entry_id)
+    tasks = Task.query.filter_by(model="pricebook_entries", record_id=entry_id).all()
+    return render_template(
+        "pricebook_entry_detail.html",
+        entry=entry,
+        tasks=tasks,
+        title="Price Book Entry Detail",
+    )
+
+
+@app.route("/pricebook_entries/<int:entry_id>/edit")
+def edit_pricebook_entry(entry_id):
+    entry = PriceBookEntry.query.get_or_404(entry_id)
+    products = Product.query.all()
+    pricebooks = Pricebook.query.all()
+    return render_template(
+        "edit_pricebook_entry.html",
+        entry=entry,
+        products=products,
+        pricebooks=pricebooks,
+        title="Edit Price Book Entry",
+    )
+
+
+@app.route("/pricebook_entries/<int:entry_id>/update", methods=["POST"])
+def update_pricebook_entry(entry_id):
+    entry = PriceBookEntry.query.get_or_404(entry_id)
+    entry.product_id = request.form.get("product_id")
+    entry.pricebook_id = request.form.get("pricebook_id")
+    entry.unit_price = request.form.get("unit_price")
+    db.session.commit()
+    return redirect(url_for("show_pricebook_entry", entry_id=entry.id))
+
+
 @app.route("/quotes")
 def list_quotes():
     quotes = Quote.query.all()
@@ -304,6 +551,31 @@ def create_quote():
     db.session.add(quote)
     db.session.commit()
     return redirect(url_for("list_quotes"))
+
+
+@app.route("/quotes/<int:quote_id>")
+def show_quote(quote_id):
+    quote = Quote.query.get_or_404(quote_id)
+    tasks = Task.query.filter_by(model="quotes", record_id=quote_id).all()
+    return render_template(
+        "quote_detail.html", quote=quote, tasks=tasks, title="Quote Detail"
+    )
+
+
+@app.route("/quotes/<int:quote_id>/edit")
+def edit_quote(quote_id):
+    quote = Quote.query.get_or_404(quote_id)
+    deals = Deal.query.all()
+    return render_template("edit_quote.html", quote=quote, deals=deals, title="Edit Quote")
+
+
+@app.route("/quotes/<int:quote_id>/update", methods=["POST"])
+def update_quote(quote_id):
+    quote = Quote.query.get_or_404(quote_id)
+    quote.deal_id = request.form.get("deal_id")
+    quote.total = request.form.get("total")
+    db.session.commit()
+    return redirect(url_for("show_quote", quote_id=quote.id))
 
 
 @app.route("/quote_line_items")
@@ -335,6 +607,69 @@ def create_quote_line_item():
     db.session.add(item)
     db.session.commit()
     return redirect(url_for("list_quote_line_items"))
+
+
+@app.route("/quote_line_items/<int:item_id>")
+def show_quote_line_item(item_id):
+    item = QuoteLineItem.query.get_or_404(item_id)
+    tasks = Task.query.filter_by(model="quote_line_items", record_id=item_id).all()
+    return render_template(
+        "quote_line_item_detail.html",
+        item=item,
+        tasks=tasks,
+        title="Quote Line Item Detail",
+    )
+
+
+@app.route("/quote_line_items/<int:item_id>/edit")
+def edit_quote_line_item(item_id):
+    item = QuoteLineItem.query.get_or_404(item_id)
+    quotes = Quote.query.all()
+    products = Product.query.all()
+    return render_template(
+        "edit_quote_line_item.html",
+        item=item,
+        quotes=quotes,
+        products=products,
+        title="Edit Quote Line Item",
+    )
+
+
+@app.route("/quote_line_items/<int:item_id>/update", methods=["POST"])
+def update_quote_line_item(item_id):
+    item = QuoteLineItem.query.get_or_404(item_id)
+    item.quote_id = request.form.get("quote_id")
+    item.product_id = request.form.get("product_id")
+    item.quantity = request.form.get("quantity")
+    item.price = request.form.get("price")
+    db.session.commit()
+    return redirect(url_for("show_quote_line_item", item_id=item.id))
+
+
+@app.route("/tasks")
+def list_tasks():
+    tasks = Task.query.all()
+    return render_template("tasks.html", tasks=tasks, title="Tasks")
+
+
+@app.route("/tasks/new/<model>/<int:record_id>")
+def new_task(model, record_id):
+    return render_template(
+        "new_task.html", model=model, record_id=record_id, title="New Task"
+    )
+
+
+@app.route("/tasks/create", methods=["POST"])
+def create_task():
+    task = Task(
+        description=request.form["description"],
+        due_date=request.form.get("due_date"),
+        model=request.form.get("model"),
+        record_id=request.form.get("record_id"),
+    )
+    db.session.add(task)
+    db.session.commit()
+    return redirect(url_for("list_tasks"))
 
 
 with app.app_context():

--- a/templates/account_detail.html
+++ b/templates/account_detail.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ account.name }}</h1>
+<p>Industry: {{ account.industry }}</p>
+<p><a class="App-link" href="{{ url_for('edit_account', account_id=account.id) }}">Edit</a></p>
+<p><a class="App-link" href="{{ url_for('new_task', model='accounts', record_id=account.id) }}">Add Task</a></p>
+<h2>Tasks</h2>
+<ul>
+{% for task in tasks %}
+<li>{{ task.description }} ({{ task.due_date }})</li>
+{% else %}
+<li>No tasks found.</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/accounts.html
+++ b/templates/accounts.html
@@ -4,13 +4,18 @@
         <header class="App-header">
             <h1>Accounts</h1>
             <p><a class="App-link" href="{{ url_for('new_account') }}">Add Account</a></p>
-            <ul>
+            <table>
+                <tr><th>Name</th><th>Industry</th><th>Actions</th></tr>
                 {% for account in accounts %}
-                    <li>{{ account.name }} - {{ account.industry or '' }}</li>
+                    <tr>
+                        <td><a href="{{ url_for('show_account', account_id=account.id) }}">{{ account.name }}</a></td>
+                        <td>{{ account.industry }}</td>
+                        <td><a href="{{ url_for('edit_account', account_id=account.id) }}">Edit</a></td>
+                    </tr>
                 {% else %}
-                    <li>No accounts found.</li>
+                    <tr><td colspan="3">No accounts found.</td></tr>
                 {% endfor %}
-            </ul>
+            </table>
         </header>
     </div>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,7 +7,7 @@
 <body>
     <nav class="navbar">
         <ul>
-            <li><a href="{{ url_for('hello_world') }}">Home</a></li>
+            <li><a href="{{ url_for('dashboard') }}">Home</a></li>
             <li><a href="{{ url_for('list_customers') }}">Customers</a></li>
             <li><a href="{{ url_for('list_leads') }}">Leads</a></li>
             <li><a href="{{ url_for('list_accounts') }}">Accounts</a></li>
@@ -16,6 +16,7 @@
             <li><a href="{{ url_for('list_products') }}">Products</a></li>
             <li><a href="{{ url_for('list_pricebooks') }}">Pricebooks</a></li>
             <li><a href="{{ url_for('list_quotes') }}">Quotes</a></li>
+            <li><a href="{{ url_for('list_tasks') }}">Tasks</a></li>
         </ul>
     </nav>
     <div class="content">

--- a/templates/contact_detail.html
+++ b/templates/contact_detail.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ contact.name }}</h1>
+<p>Email: {{ contact.email }}</p>
+<p>Phone: {{ contact.phone }}</p>
+<p>Account: {{ contact.account.name if contact.account else '' }}</p>
+<p><a class="App-link" href="{{ url_for('edit_contact', contact_id=contact.id) }}">Edit</a></p>
+<p><a class="App-link" href="{{ url_for('new_task', model='contacts', record_id=contact.id) }}">Add Task</a></p>
+<h2>Tasks</h2>
+<ul>
+{% for task in tasks %}
+<li>{{ task.description }} ({{ task.due_date }})</li>
+{% else %}
+<li>No tasks found.</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/contacts.html
+++ b/templates/contacts.html
@@ -4,13 +4,18 @@
         <header class="App-header">
             <h1>Contacts</h1>
             <p><a class="App-link" href="{{ url_for('new_contact') }}">Add Contact</a></p>
-            <ul>
+            <table>
+                <tr><th>Name</th><th>Email</th><th>Actions</th></tr>
                 {% for contact in contacts %}
-                    <li>{{ contact.name }} - {{ contact.email or '' }}</li>
+                    <tr>
+                        <td><a href="{{ url_for('show_contact', contact_id=contact.id) }}">{{ contact.name }}</a></td>
+                        <td>{{ contact.email or '' }}</td>
+                        <td><a href="{{ url_for('edit_contact', contact_id=contact.id) }}">Edit</a></td>
+                    </tr>
                 {% else %}
-                    <li>No contacts found.</li>
+                    <tr><td colspan="3">No contacts found.</td></tr>
                 {% endfor %}
-            </ul>
+            </table>
         </header>
     </div>
 {% endblock %}

--- a/templates/customer_detail.html
+++ b/templates/customer_detail.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ customer.name }}</h1>
+<p>Email: {{ customer.email }}</p>
+<p>Phone: {{ customer.phone }}</p>
+<p>Notes: {{ customer.notes }}</p>
+<p><a class="App-link" href="{{ url_for('edit_customer', customer_id=customer.id) }}">Edit</a></p>
+<p><a class="App-link" href="{{ url_for('new_task', model='customers', record_id=customer.id) }}">Add Task</a></p>
+<h2>Tasks</h2>
+<ul>
+{% for task in tasks %}
+<li>{{ task.description }} ({{ task.due_date }})</li>
+{% else %}
+<li>No tasks found.</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/customers.html
+++ b/templates/customers.html
@@ -4,13 +4,18 @@
         <header class="App-header">
             <h1>Customers</h1>
             <p><a class="App-link" href="{{ url_for('new_customer') }}">Add Customer</a></p>
-            <ul>
+            <table>
+                <tr><th>Name</th><th>Email</th><th>Actions</th></tr>
                 {% for customer in customers %}
-                    <li>{{ customer.name }} - {{ customer.email or 'No email' }}</li>
+                    <tr>
+                        <td><a href="{{ url_for('show_customer', customer_id=customer.id) }}">{{ customer.name }}</a></td>
+                        <td>{{ customer.email or '' }}</td>
+                        <td><a href="{{ url_for('edit_customer', customer_id=customer.id) }}">Edit</a></td>
+                    </tr>
                 {% else %}
-                    <li>No customers found.</li>
+                    <tr><td colspan="3">No customers found.</td></tr>
                 {% endfor %}
-            </ul>
+            </table>
         </header>
     </div>
 {% endblock %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Dashboard</h1>
+<table>
+<tr><th>Object</th><th>Count</th></tr>
+<tr><td>Customers</td><td>{{ counts.customers }}</td></tr>
+<tr><td>Leads</td><td>{{ counts.leads }}</td></tr>
+<tr><td>Accounts</td><td>{{ counts.accounts }}</td></tr>
+<tr><td>Contacts</td><td>{{ counts.contacts }}</td></tr>
+<tr><td>Deals</td><td>{{ counts.deals }}</td></tr>
+<tr><td>Products</td><td>{{ counts.products }}</td></tr>
+<tr><td>Pricebooks</td><td>{{ counts.pricebooks }}</td></tr>
+<tr><td>Quotes</td><td>{{ counts.quotes }}</td></tr>
+</table>
+{% endblock %}

--- a/templates/deal_detail.html
+++ b/templates/deal_detail.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ deal.name }}</h1>
+<p>Amount: {{ deal.amount }}</p>
+<p>Stage: {{ deal.stage }}</p>
+<p>Account: {{ deal.account.name if deal.account else '' }}</p>
+<p><a class="App-link" href="{{ url_for('edit_deal', deal_id=deal.id) }}">Edit</a></p>
+<p><a class="App-link" href="{{ url_for('new_task', model='deals', record_id=deal.id) }}">Add Task</a></p>
+<h2>Tasks</h2>
+<ul>
+{% for task in tasks %}
+<li>{{ task.description }} ({{ task.due_date }})</li>
+{% else %}
+<li>No tasks found.</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/deals.html
+++ b/templates/deals.html
@@ -4,13 +4,18 @@
         <header class="App-header">
             <h1>Deals</h1>
             <p><a class="App-link" href="{{ url_for('new_deal') }}">Add Deal</a></p>
-            <ul>
+            <table>
+                <tr><th>Name</th><th>Stage</th><th>Actions</th></tr>
                 {% for deal in deals %}
-                    <li>{{ deal.name }} - {{ deal.stage or '' }}</li>
+                    <tr>
+                        <td><a href="{{ url_for('show_deal', deal_id=deal.id) }}">{{ deal.name }}</a></td>
+                        <td>{{ deal.stage }}</td>
+                        <td><a href="{{ url_for('edit_deal', deal_id=deal.id) }}">Edit</a></td>
+                    </tr>
                 {% else %}
-                    <li>No deals found.</li>
+                    <tr><td colspan="3">No deals found.</td></tr>
                 {% endfor %}
-            </ul>
+            </table>
         </header>
     </div>
 {% endblock %}

--- a/templates/edit_account.html
+++ b/templates/edit_account.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Edit Account</h1>
+<form action="{{ url_for('update_account', account_id=account.id) }}" method="post">
+<p><input type="text" name="name" value="{{ account.name }}" required></p>
+<p><input type="text" name="industry" value="{{ account.industry }}"></p>
+<p><button type="submit">Update</button></p>
+</form>
+{% endblock %}

--- a/templates/edit_contact.html
+++ b/templates/edit_contact.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Edit Contact</h1>
+<form action="{{ url_for('update_contact', contact_id=contact.id) }}" method="post">
+<p><input type="text" name="name" value="{{ contact.name }}" required></p>
+<p><input type="email" name="email" value="{{ contact.email }}"></p>
+<p><input type="text" name="phone" value="{{ contact.phone }}"></p>
+<p>
+<select name="account_id">
+<option value="">-- Account --</option>
+{% for account in accounts %}
+<option value="{{ account.id }}" {% if contact.account_id==account.id %}selected{% endif %}>{{ account.name }}</option>
+{% endfor %}
+</select>
+</p>
+<p><button type="submit">Update</button></p>
+</form>
+{% endblock %}

--- a/templates/edit_customer.html
+++ b/templates/edit_customer.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Edit Customer</h1>
+<form action="{{ url_for('update_customer', customer_id=customer.id) }}" method="post">
+<p><input type="text" name="name" value="{{ customer.name }}" required></p>
+<p><input type="email" name="email" value="{{ customer.email }}"></p>
+<p><input type="text" name="phone" value="{{ customer.phone }}"></p>
+<p><textarea name="notes">{{ customer.notes }}</textarea></p>
+<p><button type="submit">Update</button></p>
+</form>
+{% endblock %}

--- a/templates/edit_deal.html
+++ b/templates/edit_deal.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Edit Deal</h1>
+<form action="{{ url_for('update_deal', deal_id=deal.id) }}" method="post">
+<p><input type="text" name="name" value="{{ deal.name }}" required></p>
+<p><input type="number" step="0.01" name="amount" value="{{ deal.amount }}"></p>
+<p><input type="text" name="stage" value="{{ deal.stage }}"></p>
+<p>
+<select name="account_id">
+<option value="">-- Account --</option>
+{% for account in accounts %}
+<option value="{{ account.id }}" {% if deal.account_id==account.id %}selected{% endif %}>{{ account.name }}</option>
+{% endfor %}
+</select>
+</p>
+<p><button type="submit">Update</button></p>
+</form>
+{% endblock %}

--- a/templates/edit_lead.html
+++ b/templates/edit_lead.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Edit Lead</h1>
+<form action="{{ url_for('update_lead', lead_id=lead.id) }}" method="post">
+<p><input type="text" name="name" value="{{ lead.name }}" required></p>
+<p><input type="email" name="email" value="{{ lead.email }}"></p>
+<p><input type="text" name="phone" value="{{ lead.phone }}"></p>
+<p><input type="text" name="status" value="{{ lead.status }}"></p>
+<p><button type="submit">Update</button></p>
+</form>
+{% endblock %}

--- a/templates/edit_pricebook.html
+++ b/templates/edit_pricebook.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Edit Pricebook</h1>
+<form action="{{ url_for('update_pricebook', pricebook_id=pricebook.id) }}" method="post">
+<p><input type="text" name="name" value="{{ pricebook.name }}" required></p>
+<p><button type="submit">Update</button></p>
+</form>
+{% endblock %}

--- a/templates/edit_pricebook_entry.html
+++ b/templates/edit_pricebook_entry.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Edit Price Book Entry</h1>
+<form action="{{ url_for('update_pricebook_entry', entry_id=entry.id) }}" method="post">
+<p>
+<select name="product_id">
+{% for product in products %}
+<option value="{{ product.id }}" {% if entry.product_id==product.id %}selected{% endif %}>{{ product.name }}</option>
+{% endfor %}
+</select>
+</p>
+<p>
+<select name="pricebook_id">
+{% for pricebook in pricebooks %}
+<option value="{{ pricebook.id }}" {% if entry.pricebook_id==pricebook.id %}selected{% endif %}>{{ pricebook.name }}</option>
+{% endfor %}
+</select>
+</p>
+<p><input type="number" step="0.01" name="unit_price" value="{{ entry.unit_price }}"></p>
+<p><button type="submit">Update</button></p>
+</form>
+{% endblock %}

--- a/templates/edit_product.html
+++ b/templates/edit_product.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Edit Product</h1>
+<form action="{{ url_for('update_product', product_id=product.id) }}" method="post">
+<p><input type="text" name="name" value="{{ product.name }}" required></p>
+<p><input type="number" step="0.01" name="price" value="{{ product.price }}"></p>
+<p><button type="submit">Update</button></p>
+</form>
+{% endblock %}

--- a/templates/edit_quote.html
+++ b/templates/edit_quote.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Edit Quote</h1>
+<form action="{{ url_for('update_quote', quote_id=quote.id) }}" method="post">
+<p>
+<select name="deal_id">
+{% for deal in deals %}
+<option value="{{ deal.id }}" {% if quote.deal_id==deal.id %}selected{% endif %}>{{ deal.name }}</option>
+{% endfor %}
+</select>
+</p>
+<p><input type="number" step="0.01" name="total" value="{{ quote.total }}"></p>
+<p><button type="submit">Update</button></p>
+</form>
+{% endblock %}

--- a/templates/edit_quote_line_item.html
+++ b/templates/edit_quote_line_item.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Edit Quote Line Item</h1>
+<form action="{{ url_for('update_quote_line_item', item_id=item.id) }}" method="post">
+<p>
+<select name="quote_id">
+{% for quote in quotes %}
+<option value="{{ quote.id }}" {% if item.quote_id==quote.id %}selected{% endif %}>Quote {{ quote.id }}</option>
+{% endfor %}
+</select>
+</p>
+<p>
+<select name="product_id">
+{% for product in products %}
+<option value="{{ product.id }}" {% if item.product_id==product.id %}selected{% endif %}>{{ product.name }}</option>
+{% endfor %}
+</select>
+</p>
+<p><input type="number" name="quantity" value="{{ item.quantity }}"></p>
+<p><input type="number" step="0.01" name="price" value="{{ item.price }}"></p>
+<p><button type="submit">Update</button></p>
+</form>
+{% endblock %}

--- a/templates/lead_detail.html
+++ b/templates/lead_detail.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ lead.name }}</h1>
+<p>Email: {{ lead.email }}</p>
+<p>Phone: {{ lead.phone }}</p>
+<p>Status: {{ lead.status }}</p>
+<p><a class="App-link" href="{{ url_for('edit_lead', lead_id=lead.id) }}">Edit</a></p>
+<p><a class="App-link" href="{{ url_for('new_task', model='leads', record_id=lead.id) }}">Add Task</a></p>
+<h2>Tasks</h2>
+<ul>
+{% for task in tasks %}
+<li>{{ task.description }} ({{ task.due_date }})</li>
+{% else %}
+<li>No tasks found.</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/leads.html
+++ b/templates/leads.html
@@ -4,13 +4,18 @@
         <header class="App-header">
             <h1>Leads</h1>
             <p><a class="App-link" href="{{ url_for('new_lead') }}">Add Lead</a></p>
-            <ul>
+            <table>
+                <tr><th>Name</th><th>Status</th><th>Actions</th></tr>
                 {% for lead in leads %}
-                    <li>{{ lead.name }} - {{ lead.status }}</li>
+                    <tr>
+                        <td><a href="{{ url_for('show_lead', lead_id=lead.id) }}">{{ lead.name }}</a></td>
+                        <td>{{ lead.status }}</td>
+                        <td><a href="{{ url_for('edit_lead', lead_id=lead.id) }}">Edit</a></td>
+                    </tr>
                 {% else %}
-                    <li>No leads found.</li>
+                    <tr><td colspan="3">No leads found.</td></tr>
                 {% endfor %}
-            </ul>
+            </table>
         </header>
     </div>
 {% endblock %}

--- a/templates/new_task.html
+++ b/templates/new_task.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>New Task</h1>
+<form action="{{ url_for('create_task') }}" method="post">
+<input type="hidden" name="model" value="{{ model }}">
+<input type="hidden" name="record_id" value="{{ record_id }}">
+<p><input type="text" name="description" placeholder="Description" required></p>
+<p><input type="date" name="due_date"></p>
+<p><button type="submit">Create</button></p>
+</form>
+{% endblock %}

--- a/templates/pricebook_detail.html
+++ b/templates/pricebook_detail.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ pricebook.name }}</h1>
+<p><a class="App-link" href="{{ url_for('edit_pricebook', pricebook_id=pricebook.id) }}">Edit</a></p>
+<p><a class="App-link" href="{{ url_for('new_task', model='pricebooks', record_id=pricebook.id) }}">Add Task</a></p>
+<h2>Tasks</h2>
+<ul>
+{% for task in tasks %}
+<li>{{ task.description }} ({{ task.due_date }})</li>
+{% else %}
+<li>No tasks found.</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/pricebook_entries.html
+++ b/templates/pricebook_entries.html
@@ -4,13 +4,19 @@
         <header class="App-header">
             <h1>Price Book Entries</h1>
             <p><a class="App-link" href="{{ url_for('new_pricebook_entry') }}">Add Entry</a></p>
-            <ul>
+            <table>
+                <tr><th>Product</th><th>Pricebook</th><th>Price</th><th>Actions</th></tr>
                 {% for entry in entries %}
-                    <li>{{ entry.product.name }} @ {{ entry.unit_price }} in {{ entry.pricebook.name }}</li>
+                    <tr>
+                        <td>{{ entry.product.name }}</td>
+                        <td>{{ entry.pricebook.name }}</td>
+                        <td>{{ entry.unit_price }}</td>
+                        <td><a href="{{ url_for('show_pricebook_entry', entry_id=entry.id) }}">View</a></td>
+                    </tr>
                 {% else %}
-                    <li>No entries found.</li>
+                    <tr><td colspan="4">No entries found.</td></tr>
                 {% endfor %}
-            </ul>
+            </table>
         </header>
     </div>
 {% endblock %}

--- a/templates/pricebook_entry_detail.html
+++ b/templates/pricebook_entry_detail.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Price Book Entry {{ entry.id }}</h1>
+<p>Product: {{ entry.product.name }}</p>
+<p>Pricebook: {{ entry.pricebook.name }}</p>
+<p>Unit Price: {{ entry.unit_price }}</p>
+<p><a class="App-link" href="{{ url_for('edit_pricebook_entry', entry_id=entry.id) }}">Edit</a></p>
+<p><a class="App-link" href="{{ url_for('new_task', model='pricebook_entries', record_id=entry.id) }}">Add Task</a></p>
+<h2>Tasks</h2>
+<ul>
+{% for task in tasks %}
+<li>{{ task.description }} ({{ task.due_date }})</li>
+{% else %}
+<li>No tasks found.</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/pricebooks.html
+++ b/templates/pricebooks.html
@@ -4,13 +4,17 @@
         <header class="App-header">
             <h1>Pricebooks</h1>
             <p><a class="App-link" href="{{ url_for('new_pricebook') }}">Add Pricebook</a></p>
-            <ul>
+            <table>
+                <tr><th>Name</th><th>Actions</th></tr>
                 {% for pricebook in pricebooks %}
-                    <li>{{ pricebook.name }}</li>
+                    <tr>
+                        <td><a href="{{ url_for('show_pricebook', pricebook_id=pricebook.id) }}">{{ pricebook.name }}</a></td>
+                        <td><a href="{{ url_for('edit_pricebook', pricebook_id=pricebook.id) }}">Edit</a></td>
+                    </tr>
                 {% else %}
-                    <li>No pricebooks found.</li>
+                    <tr><td colspan="2">No pricebooks found.</td></tr>
                 {% endfor %}
-            </ul>
+            </table>
         </header>
     </div>
 {% endblock %}

--- a/templates/product_detail.html
+++ b/templates/product_detail.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ product.name }}</h1>
+<p>Price: {{ product.price }}</p>
+<p><a class="App-link" href="{{ url_for('edit_product', product_id=product.id) }}">Edit</a></p>
+<p><a class="App-link" href="{{ url_for('new_task', model='products', record_id=product.id) }}">Add Task</a></p>
+<h2>Tasks</h2>
+<ul>
+{% for task in tasks %}
+<li>{{ task.description }} ({{ task.due_date }})</li>
+{% else %}
+<li>No tasks found.</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/products.html
+++ b/templates/products.html
@@ -4,13 +4,18 @@
         <header class="App-header">
             <h1>Products</h1>
             <p><a class="App-link" href="{{ url_for('new_product') }}">Add Product</a></p>
-            <ul>
+            <table>
+                <tr><th>Name</th><th>Price</th><th>Actions</th></tr>
                 {% for product in products %}
-                    <li>{{ product.name }} - {{ product.price }}</li>
+                    <tr>
+                        <td><a href="{{ url_for('show_product', product_id=product.id) }}">{{ product.name }}</a></td>
+                        <td>{{ product.price }}</td>
+                        <td><a href="{{ url_for('edit_product', product_id=product.id) }}">Edit</a></td>
+                    </tr>
                 {% else %}
-                    <li>No products found.</li>
+                    <tr><td colspan="3">No products found.</td></tr>
                 {% endfor %}
-            </ul>
+            </table>
         </header>
     </div>
 {% endblock %}

--- a/templates/quote_detail.html
+++ b/templates/quote_detail.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Quote {{ quote.id }}</h1>
+<p>Deal: {{ quote.deal.name if quote.deal else '' }}</p>
+<p>Total: {{ quote.total }}</p>
+<p><a class="App-link" href="{{ url_for('edit_quote', quote_id=quote.id) }}">Edit</a></p>
+<p><a class="App-link" href="{{ url_for('new_task', model='quotes', record_id=quote.id) }}">Add Task</a></p>
+<h2>Tasks</h2>
+<ul>
+{% for task in tasks %}
+<li>{{ task.description }} ({{ task.due_date }})</li>
+{% else %}
+<li>No tasks found.</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/quote_line_item_detail.html
+++ b/templates/quote_line_item_detail.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Quote Line Item {{ item.id }}</h1>
+<p>Quote: {{ item.quote.id }}</p>
+<p>Product: {{ item.product.name }}</p>
+<p>Quantity: {{ item.quantity }}</p>
+<p>Price: {{ item.price }}</p>
+<p><a class="App-link" href="{{ url_for('edit_quote_line_item', item_id=item.id) }}">Edit</a></p>
+<p><a class="App-link" href="{{ url_for('new_task', model='quote_line_items', record_id=item.id) }}">Add Task</a></p>
+<h2>Tasks</h2>
+<ul>
+{% for task in tasks %}
+<li>{{ task.description }} ({{ task.due_date }})</li>
+{% else %}
+<li>No tasks found.</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/quote_line_items.html
+++ b/templates/quote_line_items.html
@@ -4,13 +4,20 @@
         <header class="App-header">
             <h1>Quote Line Items</h1>
             <p><a class="App-link" href="{{ url_for('new_quote_line_item') }}">Add Line Item</a></p>
-            <ul>
+            <table>
+                <tr><th>Quote</th><th>Product</th><th>Qty</th><th>Price</th><th>Actions</th></tr>
                 {% for item in items %}
-                    <li>{{ item.quote.id }} - {{ item.product.name }} x {{ item.quantity }} @ {{ item.price }}</li>
+                    <tr>
+                        <td>{{ item.quote.id }}</td>
+                        <td>{{ item.product.name }}</td>
+                        <td>{{ item.quantity }}</td>
+                        <td>{{ item.price }}</td>
+                        <td><a href="{{ url_for('show_quote_line_item', item_id=item.id) }}">View</a></td>
+                    </tr>
                 {% else %}
-                    <li>No items found.</li>
+                    <tr><td colspan="5">No items found.</td></tr>
                 {% endfor %}
-            </ul>
+            </table>
         </header>
     </div>
 {% endblock %}

--- a/templates/quotes.html
+++ b/templates/quotes.html
@@ -4,13 +4,19 @@
         <header class="App-header">
             <h1>Quotes</h1>
             <p><a class="App-link" href="{{ url_for('new_quote') }}">Add Quote</a></p>
-            <ul>
+            <table>
+                <tr><th>ID</th><th>Deal</th><th>Total</th><th>Actions</th></tr>
                 {% for quote in quotes %}
-                    <li>Quote {{ quote.id }} for {{ quote.deal.name }} - total {{ quote.total }}</li>
+                    <tr>
+                        <td><a href="{{ url_for('show_quote', quote_id=quote.id) }}">{{ quote.id }}</a></td>
+                        <td>{{ quote.deal.name }}</td>
+                        <td>{{ quote.total }}</td>
+                        <td><a href="{{ url_for('edit_quote', quote_id=quote.id) }}">Edit</a></td>
+                    </tr>
                 {% else %}
-                    <li>No quotes found.</li>
+                    <tr><td colspan="4">No quotes found.</td></tr>
                 {% endfor %}
-            </ul>
+            </table>
             <p><a class="App-link" href="{{ url_for('list_quote_line_items') }}">Quote Line Items</a></p>
         </header>
     </div>

--- a/templates/tasks.html
+++ b/templates/tasks.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Tasks</h1>
+<p><a class="App-link" href="{{ url_for('dashboard') }}">Back to Dashboard</a></p>
+<table>
+<tr><th>Description</th><th>Due</th><th>Model</th><th>Record</th></tr>
+{% for task in tasks %}
+<tr>
+<td>{{ task.description }}</td>
+<td>{{ task.due_date or '' }}</td>
+<td>{{ task.model }}</td>
+<td>{{ task.record_id }}</td>
+</tr>
+{% else %}
+<tr><td colspan="4">No tasks found.</td></tr>
+{% endfor %}
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- enable editing views for CRM objects
- create dashboard overview with record counts
- add generic task tracking with related list views
- show data in tables with links to details
- include detail pages and editing forms

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846a7277cf88330bfe360cffd265cbc