### PR TITLE
Lead conversion and unified accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to your shiny new Codespace running Flask! We've got everything fired up and running for you to explore Flask.
 This project now contains a simple Customer Relationship Management (CRM) application
-built with Flask and SQLite. It allows you to create and list customers.
+built with Flask and SQLite. It allows you to manage accounts, leads and contacts.
 
 You've got a blank canvas to work on from a git perspective as well. There's a single initial commit with the what you're seeing right now - where you go from here is up to you!
 

--- a/static/main.css
+++ b/static/main.css
@@ -1,8 +1,7 @@
 body {
     margin: 0;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-        "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-        sans-serif;
+    background: #f3f2f2;
+    font-family: Arial, Helvetica, sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 }
@@ -44,7 +43,7 @@ code {
     font-size: 0.75rem;
 }
 .navbar {
-    background-color: #333;
+    background-color: #16325c;
     padding: 0.5rem 1rem;
 }
 .navbar ul {
@@ -62,4 +61,20 @@ code {
 }
 .content {
     padding: 1rem;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+th,
+td {
+    border: 1px solid #d8dde6;
+    padding: 0.5rem;
+    text-align: left;
+}
+
+th {
+    background: #f3f2f2;
 }

--- a/templates/account_detail.html
+++ b/templates/account_detail.html
@@ -2,6 +2,9 @@
 {% block content %}
 <h1>{{ account.name }}</h1>
 <p>Industry: {{ account.industry }}</p>
+<p>Email: {{ account.email }}</p>
+<p>Phone: {{ account.phone }}</p>
+<p>Notes: {{ account.notes }}</p>
 <p><a class="App-link" href="{{ url_for('edit_account', account_id=account.id) }}">Edit</a></p>
 <p><a class="App-link" href="{{ url_for('new_task', model='accounts', record_id=account.id) }}">Add Task</a></p>
 <h2>Tasks</h2>

--- a/templates/accounts.html
+++ b/templates/accounts.html
@@ -5,15 +5,17 @@
             <h1>Accounts</h1>
             <p><a class="App-link" href="{{ url_for('new_account') }}">Add Account</a></p>
             <table>
-                <tr><th>Name</th><th>Industry</th><th>Actions</th></tr>
+                <tr><th>Name</th><th>Industry</th><th>Email</th><th>Phone</th><th>Actions</th></tr>
                 {% for account in accounts %}
                     <tr>
                         <td><a href="{{ url_for('show_account', account_id=account.id) }}">{{ account.name }}</a></td>
                         <td>{{ account.industry }}</td>
+                        <td>{{ account.email }}</td>
+                        <td>{{ account.phone }}</td>
                         <td><a href="{{ url_for('edit_account', account_id=account.id) }}">Edit</a></td>
                     </tr>
                 {% else %}
-                    <tr><td colspan="3">No accounts found.</td></tr>
+                    <tr><td colspan="5">No accounts found.</td></tr>
                 {% endfor %}
             </table>
         </header>

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,7 +8,6 @@
     <nav class="navbar">
         <ul>
             <li><a href="{{ url_for('dashboard') }}">Home</a></li>
-            <li><a href="{{ url_for('list_customers') }}">Customers</a></li>
             <li><a href="{{ url_for('list_leads') }}">Leads</a></li>
             <li><a href="{{ url_for('list_accounts') }}">Accounts</a></li>
             <li><a href="{{ url_for('list_contacts') }}">Contacts</a></li>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -3,7 +3,6 @@
 <h1>Dashboard</h1>
 <table>
 <tr><th>Object</th><th>Count</th></tr>
-<tr><td>Customers</td><td>{{ counts.customers }}</td></tr>
 <tr><td>Leads</td><td>{{ counts.leads }}</td></tr>
 <tr><td>Accounts</td><td>{{ counts.accounts }}</td></tr>
 <tr><td>Contacts</td><td>{{ counts.contacts }}</td></tr>

--- a/templates/edit_account.html
+++ b/templates/edit_account.html
@@ -4,6 +4,9 @@
 <form action="{{ url_for('update_account', account_id=account.id) }}" method="post">
 <p><input type="text" name="name" value="{{ account.name }}" required></p>
 <p><input type="text" name="industry" value="{{ account.industry }}"></p>
+<p><input type="email" name="email" value="{{ account.email }}"></p>
+<p><input type="text" name="phone" value="{{ account.phone }}"></p>
+<p><textarea name="notes">{{ account.notes }}</textarea></p>
 <p><button type="submit">Update</button></p>
 </form>
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,7 @@
                 This is the home page of your CRM application.
             </p>
             <p>
-                <a class="App-link" href="{{ url_for('list_customers') }}">View Customers</a>
+                <a class="App-link" href="{{ url_for('list_accounts') }}">View Accounts</a>
             </p>
         </header>
     </div>

--- a/templates/lead_detail.html
+++ b/templates/lead_detail.html
@@ -5,6 +5,9 @@
 <p>Phone: {{ lead.phone }}</p>
 <p>Status: {{ lead.status }}</p>
 <p><a class="App-link" href="{{ url_for('edit_lead', lead_id=lead.id) }}">Edit</a></p>
+<form action="{{ url_for('convert_lead', lead_id=lead.id) }}" method="post" style="display:inline;">
+    <button type="submit">Convert to Account</button>
+</form>
 <p><a class="App-link" href="{{ url_for('new_task', model='leads', record_id=lead.id) }}">Add Task</a></p>
 <h2>Tasks</h2>
 <ul>

--- a/templates/new_account.html
+++ b/templates/new_account.html
@@ -6,6 +6,9 @@
             <form action="{{ url_for('create_account') }}" method="post">
                 <p><input type="text" name="name" placeholder="Name" required></p>
                 <p><input type="text" name="industry" placeholder="Industry"></p>
+                <p><input type="email" name="email" placeholder="Email"></p>
+                <p><input type="text" name="phone" placeholder="Phone"></p>
+                <p><textarea name="notes" placeholder="Notes"></textarea></p>
                 <p><button type="submit">Create</button></p>
             </form>
             <p><a class="App-link" href="{{ url_for('list_accounts') }}">Back</a></p>


### PR DESCRIPTION
## Summary
- update README to reflect account focus
- merge Customer fields into Account model
- remove Customers navigation items and counts
- enable lead conversion to account and contact
- show account email, phone and notes
- restyle with Salesforce-like theme

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6846a9bd93748330b58e7b8850f1238b