### PR TITLE
Implement login system and admin area

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==2.3.2
 Flask-SQLAlchemy==3.0.5
+Flask-Login==0.6.2

--- a/static/main.css
+++ b/static/main.css
@@ -55,6 +55,9 @@ code {
 .navbar li {
     margin-right: 1rem;
 }
+.navbar li.right {
+    margin-left: auto;
+}
 .navbar a {
     color: white;
     text-decoration: none;
@@ -77,4 +80,26 @@ td {
 
 th {
     background: #f3f2f2;
+}
+
+.two-column {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    max-width: 800px;
+    margin: auto;
+}
+
+.kanban {
+    display: flex;
+    gap: 1rem;
+}
+.kanban-column {
+    flex: 1;
+    background: #fff;
+    border: 1px solid #d8dde6;
+    padding: 0.5rem;
+}
+.kanban-column h3 {
+    text-align: center;
 }

--- a/templates/account_detail.html
+++ b/templates/account_detail.html
@@ -4,6 +4,7 @@
 <p>Industry: {{ account.industry }}</p>
 <p>Email: {{ account.email }}</p>
 <p>Phone: {{ account.phone }}</p>
+<p>Address: {{ account.address }}</p>
 <p>Notes: {{ account.notes }}</p>
 <p><a class="App-link" href="{{ url_for('edit_account', account_id=account.id) }}">Edit</a></p>
 <p><a class="App-link" href="{{ url_for('new_task', model='accounts', record_id=account.id) }}">Add Task</a></p>

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,0 +1,24 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>User Administration</h1>
+<form action="{{ url_for('create_user') }}" method="post" class="two-column">
+<p><input type="text" name="username" placeholder="Username" required></p>
+<p><input type="password" name="password" placeholder="Password" required></p>
+<p><button type="submit">Create User</button></p>
+</form>
+<table>
+<tr><th>User</th><th>Action</th></tr>
+{% for user in users %}
+<tr>
+<td>{{ user.username }}</td>
+<td>
+    {% if not user.is_admin %}
+    <form action="{{ url_for('delete_user', user_id=user.id) }}" method="post" style="display:inline;">
+        <button type="submit">Delete</button>
+    </form>
+    {% endif %}
+</td>
+</tr>
+{% endfor %}
+</table>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,6 +16,14 @@
             <li><a href="{{ url_for('list_pricebooks') }}">Pricebooks</a></li>
             <li><a href="{{ url_for('list_quotes') }}">Quotes</a></li>
             <li><a href="{{ url_for('list_tasks') }}">Tasks</a></li>
+            {% if current_user.is_authenticated %}
+                {% if current_user.is_admin %}
+                    <li class="right"><a href="{{ url_for('admin') }}">Admin</a></li>
+                {% endif %}
+                <li class="right"><a href="{{ url_for('logout') }}">Logout</a></li>
+            {% else %}
+                <li class="right"><a href="{{ url_for('login') }}">Login</a></li>
+            {% endif %}
         </ul>
     </nav>
     <div class="content">

--- a/templates/contact_detail.html
+++ b/templates/contact_detail.html
@@ -3,6 +3,7 @@
 <h1>{{ contact.name }}</h1>
 <p>Email: {{ contact.email }}</p>
 <p>Phone: {{ contact.phone }}</p>
+<p>Title: {{ contact.title }}</p>
 <p>Account: {{ contact.account.name if contact.account else '' }}</p>
 <p><a class="App-link" href="{{ url_for('edit_contact', contact_id=contact.id) }}">Edit</a></p>
 <p><a class="App-link" href="{{ url_for('new_task', model='contacts', record_id=contact.id) }}">Add Task</a></p>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,14 +1,33 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Dashboard</h1>
-<table>
-<tr><th>Object</th><th>Count</th></tr>
-<tr><td>Leads</td><td>{{ counts.leads }}</td></tr>
-<tr><td>Accounts</td><td>{{ counts.accounts }}</td></tr>
-<tr><td>Contacts</td><td>{{ counts.contacts }}</td></tr>
-<tr><td>Deals</td><td>{{ counts.deals }}</td></tr>
-<tr><td>Products</td><td>{{ counts.products }}</td></tr>
-<tr><td>Pricebooks</td><td>{{ counts.pricebooks }}</td></tr>
-<tr><td>Quotes</td><td>{{ counts.quotes }}</td></tr>
-</table>
+<div class="two-column">
+    <div>
+        <canvas id="countChart"></canvas>
+    </div>
+    <div>
+        <h2>Tasks</h2>
+        <ul>
+        {% for task in tasks %}
+            <li>{{ task.description }} ({{ task.status }})</li>
+        {% else %}
+            <li>No tasks</li>
+        {% endfor %}
+        </ul>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+const ctx = document.getElementById('countChart').getContext('2d');
+new Chart(ctx, {
+    type: 'bar',
+    data: {
+        labels: ['Leads','Accounts','Contacts','Deals','Products','Pricebooks','Quotes'],
+        datasets: [{
+            label: 'Records',
+            data: [{{ counts.leads }},{{ counts.accounts }},{{ counts.contacts }},{{ counts.deals }},{{ counts.products }},{{ counts.pricebooks }},{{ counts.quotes }}]
+        }]
+    }
+});
+</script>
 {% endblock %}

--- a/templates/deal_detail.html
+++ b/templates/deal_detail.html
@@ -3,6 +3,7 @@
 <h1>{{ deal.name }}</h1>
 <p>Amount: {{ deal.amount }}</p>
 <p>Stage: {{ deal.stage }}</p>
+<p>Close Date: {{ deal.close_date }}</p>
 <p>Account: {{ deal.account.name if deal.account else '' }}</p>
 <p><a class="App-link" href="{{ url_for('edit_deal', deal_id=deal.id) }}">Edit</a></p>
 <p><a class="App-link" href="{{ url_for('new_task', model='deals', record_id=deal.id) }}">Add Task</a></p>

--- a/templates/edit_account.html
+++ b/templates/edit_account.html
@@ -1,11 +1,12 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Edit Account</h1>
-<form action="{{ url_for('update_account', account_id=account.id) }}" method="post">
+<form action="{{ url_for('update_account', account_id=account.id) }}" method="post" class="two-column">
 <p><input type="text" name="name" value="{{ account.name }}" required></p>
 <p><input type="text" name="industry" value="{{ account.industry }}"></p>
 <p><input type="email" name="email" value="{{ account.email }}"></p>
 <p><input type="text" name="phone" value="{{ account.phone }}"></p>
+<p><input type="text" name="address" value="{{ account.address }}"></p>
 <p><textarea name="notes">{{ account.notes }}</textarea></p>
 <p><button type="submit">Update</button></p>
 </form>

--- a/templates/edit_contact.html
+++ b/templates/edit_contact.html
@@ -1,10 +1,11 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Edit Contact</h1>
-<form action="{{ url_for('update_contact', contact_id=contact.id) }}" method="post">
+<form action="{{ url_for('update_contact', contact_id=contact.id) }}" method="post" class="two-column">
 <p><input type="text" name="name" value="{{ contact.name }}" required></p>
 <p><input type="email" name="email" value="{{ contact.email }}"></p>
 <p><input type="text" name="phone" value="{{ contact.phone }}"></p>
+<p><input type="text" name="title" value="{{ contact.title }}"></p>
 <p>
 <select name="account_id">
 <option value="">-- Account --</option>

--- a/templates/edit_deal.html
+++ b/templates/edit_deal.html
@@ -1,10 +1,17 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Edit Deal</h1>
-<form action="{{ url_for('update_deal', deal_id=deal.id) }}" method="post">
+<form action="{{ url_for('update_deal', deal_id=deal.id) }}" method="post" class="two-column">
 <p><input type="text" name="name" value="{{ deal.name }}" required></p>
 <p><input type="number" step="0.01" name="amount" value="{{ deal.amount }}"></p>
-<p><input type="text" name="stage" value="{{ deal.stage }}"></p>
+<p>
+    <select name="stage">
+        {% for s in stages %}
+            <option value="{{ s.value }}" {% if s.value == deal.stage %}selected{% endif %}>{{ s.value }}</option>
+        {% endfor %}
+    </select>
+</p>
+<p><input type="date" name="close_date" value="{{ deal.close_date }}"></p>
 <p>
 <select name="account_id">
 <option value="">-- Account --</option>

--- a/templates/edit_lead.html
+++ b/templates/edit_lead.html
@@ -1,11 +1,19 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Edit Lead</h1>
-<form action="{{ url_for('update_lead', lead_id=lead.id) }}" method="post">
+<form action="{{ url_for('update_lead', lead_id=lead.id) }}" method="post" class="two-column">
 <p><input type="text" name="name" value="{{ lead.name }}" required></p>
 <p><input type="email" name="email" value="{{ lead.email }}"></p>
 <p><input type="text" name="phone" value="{{ lead.phone }}"></p>
-<p><input type="text" name="status" value="{{ lead.status }}"></p>
+<p><input type="text" name="company" value="{{ lead.company }}"></p>
+<p><textarea name="notes">{{ lead.notes }}</textarea></p>
+<p>
+    <select name="status">
+        {% for s in statuses %}
+            <option value="{{ s.value }}" {% if s.value == lead.status %}selected{% endif %}>{{ s.value }}</option>
+        {% endfor %}
+    </select>
+</p>
 <p><button type="submit">Update</button></p>
 </form>
 {% endblock %}

--- a/templates/edit_pricebook.html
+++ b/templates/edit_pricebook.html
@@ -1,8 +1,9 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Edit Pricebook</h1>
-<form action="{{ url_for('update_pricebook', pricebook_id=pricebook.id) }}" method="post">
+<form action="{{ url_for('update_pricebook', pricebook_id=pricebook.id) }}" method="post" class="two-column">
 <p><input type="text" name="name" value="{{ pricebook.name }}" required></p>
+<p><textarea name="description">{{ pricebook.description }}</textarea></p>
 <p><button type="submit">Update</button></p>
 </form>
 {% endblock %}

--- a/templates/edit_product.html
+++ b/templates/edit_product.html
@@ -1,9 +1,10 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Edit Product</h1>
-<form action="{{ url_for('update_product', product_id=product.id) }}" method="post">
+<form action="{{ url_for('update_product', product_id=product.id) }}" method="post" class="two-column">
 <p><input type="text" name="name" value="{{ product.name }}" required></p>
 <p><input type="number" step="0.01" name="price" value="{{ product.price }}"></p>
+<p><textarea name="description">{{ product.description }}</textarea></p>
 <p><button type="submit">Update</button></p>
 </form>
 {% endblock %}

--- a/templates/edit_quote.html
+++ b/templates/edit_quote.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Edit Quote</h1>
-<form action="{{ url_for('update_quote', quote_id=quote.id) }}" method="post">
+<form action="{{ url_for('update_quote', quote_id=quote.id) }}" method="post" class="two-column">
 <p>
 <select name="deal_id">
 {% for deal in deals %}
@@ -10,6 +10,7 @@
 </select>
 </p>
 <p><input type="number" step="0.01" name="total" value="{{ quote.total }}"></p>
+<p><input type="date" name="expiration_date" value="{{ quote.expiration_date }}"></p>
 <p><button type="submit">Update</button></p>
 </form>
 {% endblock %}

--- a/templates/kanban.html
+++ b/templates/kanban.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ title }}</h1>
+<div class="kanban">
+    {% for status, records in columns.items() %}
+    <div class="kanban-column">
+        <h3>{{ status }}</h3>
+        <ul>
+        {% for r in records %}
+            <li>{{ r.name if r.name else r.description }}</li>
+        {% else %}
+            <li>None</li>
+        {% endfor %}
+        </ul>
+    </div>
+    {% endfor %}
+</div>
+{% endblock %}

--- a/templates/lead_detail.html
+++ b/templates/lead_detail.html
@@ -3,6 +3,8 @@
 <h1>{{ lead.name }}</h1>
 <p>Email: {{ lead.email }}</p>
 <p>Phone: {{ lead.phone }}</p>
+<p>Company: {{ lead.company }}</p>
+<p>Notes: {{ lead.notes }}</p>
 <p>Status: {{ lead.status }}</p>
 <p><a class="App-link" href="{{ url_for('edit_lead', lead_id=lead.id) }}">Edit</a></p>
 <form action="{{ url_for('convert_lead', lead_id=lead.id) }}" method="post" style="display:inline;">

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Login</h1>
+<form action="{{ url_for('login') }}" method="post" class="two-column">
+<p><input type="text" name="username" placeholder="Username" required></p>
+<p><input type="password" name="password" placeholder="Password" required></p>
+<p><button type="submit">Login</button></p>
+</form>
+{% endblock %}

--- a/templates/new_account.html
+++ b/templates/new_account.html
@@ -3,11 +3,12 @@
     <div class="App">
         <header class="App-header">
             <h1>New Account</h1>
-            <form action="{{ url_for('create_account') }}" method="post">
+            <form action="{{ url_for('create_account') }}" method="post" class="two-column">
                 <p><input type="text" name="name" placeholder="Name" required></p>
                 <p><input type="text" name="industry" placeholder="Industry"></p>
                 <p><input type="email" name="email" placeholder="Email"></p>
                 <p><input type="text" name="phone" placeholder="Phone"></p>
+                <p><input type="text" name="address" placeholder="Address"></p>
                 <p><textarea name="notes" placeholder="Notes"></textarea></p>
                 <p><button type="submit">Create</button></p>
             </form>

--- a/templates/new_contact.html
+++ b/templates/new_contact.html
@@ -3,10 +3,11 @@
     <div class="App">
         <header class="App-header">
             <h1>New Contact</h1>
-            <form action="{{ url_for('create_contact') }}" method="post">
+            <form action="{{ url_for('create_contact') }}" method="post" class="two-column">
                 <p><input type="text" name="name" placeholder="Name" required></p>
                 <p><input type="email" name="email" placeholder="Email"></p>
                 <p><input type="text" name="phone" placeholder="Phone"></p>
+                <p><input type="text" name="title" placeholder="Title"></p>
                 <p>
                     <select name="account_id">
                         <option value="">-- Account --</option>

--- a/templates/new_deal.html
+++ b/templates/new_deal.html
@@ -3,10 +3,17 @@
     <div class="App">
         <header class="App-header">
             <h1>New Deal</h1>
-            <form action="{{ url_for('create_deal') }}" method="post">
+            <form action="{{ url_for('create_deal') }}" method="post" class="two-column">
                 <p><input type="text" name="name" placeholder="Name" required></p>
                 <p><input type="number" step="0.01" name="amount" placeholder="Amount"></p>
-                <p><input type="text" name="stage" placeholder="Stage"></p>
+                <p>
+                    <select name="stage">
+                        {% for s in stages %}
+                            <option value="{{ s.value }}">{{ s.value }}</option>
+                        {% endfor %}
+                    </select>
+                </p>
+                <p><input type="date" name="close_date"></p>
                 <p>
                     <select name="account_id">
                         <option value="">-- Account --</option>

--- a/templates/new_lead.html
+++ b/templates/new_lead.html
@@ -3,11 +3,19 @@
     <div class="App">
         <header class="App-header">
             <h1>New Lead</h1>
-            <form action="{{ url_for('create_lead') }}" method="post">
+            <form action="{{ url_for('create_lead') }}" method="post" class="two-column">
                 <p><input type="text" name="name" placeholder="Name" required></p>
                 <p><input type="email" name="email" placeholder="Email"></p>
                 <p><input type="text" name="phone" placeholder="Phone"></p>
-                <p><input type="text" name="status" placeholder="Status"></p>
+                <p><input type="text" name="company" placeholder="Company"></p>
+                <p><textarea name="notes" placeholder="Notes"></textarea></p>
+                <p>
+                    <select name="status">
+                        {% for s in statuses %}
+                            <option value="{{ s.value }}">{{ s.value }}</option>
+                        {% endfor %}
+                    </select>
+                </p>
                 <p><button type="submit">Create</button></p>
             </form>
             <p><a class="App-link" href="{{ url_for('list_leads') }}">Back</a></p>

--- a/templates/new_pricebook.html
+++ b/templates/new_pricebook.html
@@ -3,8 +3,9 @@
     <div class="App">
         <header class="App-header">
             <h1>New Pricebook</h1>
-            <form action="{{ url_for('create_pricebook') }}" method="post">
+            <form action="{{ url_for('create_pricebook') }}" method="post" class="two-column">
                 <p><input type="text" name="name" placeholder="Name" required></p>
+                <p><textarea name="description" placeholder="Description"></textarea></p>
                 <p><button type="submit">Create</button></p>
             </form>
             <p><a class="App-link" href="{{ url_for('list_pricebooks') }}">Back</a></p>

--- a/templates/new_product.html
+++ b/templates/new_product.html
@@ -3,9 +3,10 @@
     <div class="App">
         <header class="App-header">
             <h1>New Product</h1>
-            <form action="{{ url_for('create_product') }}" method="post">
+            <form action="{{ url_for('create_product') }}" method="post" class="two-column">
                 <p><input type="text" name="name" placeholder="Name" required></p>
                 <p><input type="number" step="0.01" name="price" placeholder="Price"></p>
+                <p><textarea name="description" placeholder="Description"></textarea></p>
                 <p><button type="submit">Create</button></p>
             </form>
             <p><a class="App-link" href="{{ url_for('list_products') }}">Back</a></p>

--- a/templates/new_quote.html
+++ b/templates/new_quote.html
@@ -3,7 +3,7 @@
     <div class="App">
         <header class="App-header">
             <h1>New Quote</h1>
-            <form action="{{ url_for('create_quote') }}" method="post">
+            <form action="{{ url_for('create_quote') }}" method="post" class="two-column">
                 <p>
                     <select name="deal_id">
                         {% for deal in deals %}
@@ -12,6 +12,7 @@
                     </select>
                 </p>
                 <p><input type="number" step="0.01" name="total" placeholder="Total"></p>
+                <p><input type="date" name="expiration_date" placeholder="Expiration"></p>
                 <p><button type="submit">Create</button></p>
             </form>
             <p><a class="App-link" href="{{ url_for('list_quotes') }}">Back</a></p>

--- a/templates/new_task.html
+++ b/templates/new_task.html
@@ -1,11 +1,18 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>New Task</h1>
-<form action="{{ url_for('create_task') }}" method="post">
+<form action="{{ url_for('create_task') }}" method="post" class="two-column">
 <input type="hidden" name="model" value="{{ model }}">
 <input type="hidden" name="record_id" value="{{ record_id }}">
 <p><input type="text" name="description" placeholder="Description" required></p>
 <p><input type="date" name="due_date"></p>
+<p>
+    <select name="status">
+        {% for s in statuses %}
+            <option value="{{ s.value }}">{{ s.value }}</option>
+        {% endfor %}
+    </select>
+</p>
 <p><button type="submit">Create</button></p>
 </form>
 {% endblock %}

--- a/templates/pricebook_detail.html
+++ b/templates/pricebook_detail.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>{{ pricebook.name }}</h1>
+<p>Description: {{ pricebook.description }}</p>
 <p><a class="App-link" href="{{ url_for('edit_pricebook', pricebook_id=pricebook.id) }}">Edit</a></p>
 <p><a class="App-link" href="{{ url_for('new_task', model='pricebooks', record_id=pricebook.id) }}">Add Task</a></p>
 <h2>Tasks</h2>

--- a/templates/product_detail.html
+++ b/templates/product_detail.html
@@ -2,6 +2,7 @@
 {% block content %}
 <h1>{{ product.name }}</h1>
 <p>Price: {{ product.price }}</p>
+<p>Description: {{ product.description }}</p>
 <p><a class="App-link" href="{{ url_for('edit_product', product_id=product.id) }}">Edit</a></p>
 <p><a class="App-link" href="{{ url_for('new_task', model='products', record_id=product.id) }}">Add Task</a></p>
 <h2>Tasks</h2>

--- a/templates/quote_detail.html
+++ b/templates/quote_detail.html
@@ -3,6 +3,7 @@
 <h1>Quote {{ quote.id }}</h1>
 <p>Deal: {{ quote.deal.name if quote.deal else '' }}</p>
 <p>Total: {{ quote.total }}</p>
+<p>Expiration: {{ quote.expiration_date }}</p>
 <p><a class="App-link" href="{{ url_for('edit_quote', quote_id=quote.id) }}">Edit</a></p>
 <p><a class="App-link" href="{{ url_for('new_task', model='quotes', record_id=quote.id) }}">Add Task</a></p>
 <h2>Tasks</h2>

--- a/templates/tasks.html
+++ b/templates/tasks.html
@@ -3,16 +3,17 @@
 <h1>Tasks</h1>
 <p><a class="App-link" href="{{ url_for('dashboard') }}">Back to Dashboard</a></p>
 <table>
-<tr><th>Description</th><th>Due</th><th>Model</th><th>Record</th></tr>
+<tr><th>Description</th><th>Due</th><th>Status</th><th>Model</th><th>Record</th></tr>
 {% for task in tasks %}
 <tr>
 <td>{{ task.description }}</td>
 <td>{{ task.due_date or '' }}</td>
+<td>{{ task.status }}</td>
 <td>{{ task.model }}</td>
 <td>{{ task.record_id }}</td>
 </tr>
 {% else %}
-<tr><td colspan="4">No tasks found.</td></tr>
+<tr><td colspan="5">No tasks found.</td></tr>
 {% endfor %}
 </table>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add Flask-Login and authentication
- create admin area and user management
- create default admin user and status defaults
- expand models with additional fields
- overhaul dashboard with chart and task list
- add Kanban boards for leads, deals and tasks
- apply two-column layout and new CSS helpers

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6846b2e88948833095afede8b89833e8