### PR TITLE
Fix login dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,14 @@ To run this application:
 flask --debug run
 ```
 
+Ensure dependencies are installed with:
+
+```
+pip install -r requirements.txt
+```
+
+The requirements pin `Werkzeug<3` to avoid an incompatibility between
+Flask-Login and newer Werkzeug releases.
+
 On first launch the application will create an SQLite database file named
 `crm.db` in the project directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==2.3.2
 Flask-SQLAlchemy==3.0.5
-Flask-Login==0.6.2
+Flask-Login>=0.6.3
+Werkzeug<3


### PR DESCRIPTION
## Summary
- pin Werkzeug to remain below version 3
- install dependencies before running the app
- document the compatibility pin

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846b5ab5500833086d75b2e8c4ee4e1