### PR TITLE
Add Kanban switch and status management

### DIFF
--- a/app.py
+++ b/app.py
@@ -802,6 +802,49 @@ def delete_user(user_id):
     return redirect(url_for("admin"))
 
 
+@app.route("/admin/statuses")
+@login_required
+def manage_statuses():
+    if not current_user.is_admin:
+        return redirect(url_for("dashboard"))
+    statuses = StatusOption.query.all()
+    return render_template("statuses.html", statuses=statuses, title="Manage Statuses")
+
+
+@app.route("/admin/statuses/create", methods=["POST"])
+@login_required
+def create_status():
+    if not current_user.is_admin:
+        return redirect(url_for("dashboard"))
+    db.session.add(
+        StatusOption(model=request.form["model"], value=request.form["value"])
+    )
+    db.session.commit()
+    return redirect(url_for("manage_statuses"))
+
+
+@app.route("/admin/statuses/<int:status_id>/update", methods=["POST"])
+@login_required
+def update_status(status_id):
+    if not current_user.is_admin:
+        return redirect(url_for("dashboard"))
+    status = StatusOption.query.get_or_404(status_id)
+    status.value = request.form["value"]
+    db.session.commit()
+    return redirect(url_for("manage_statuses"))
+
+
+@app.route("/admin/statuses/<int:status_id>/delete", methods=["POST"])
+@login_required
+def delete_status(status_id):
+    if not current_user.is_admin:
+        return redirect(url_for("dashboard"))
+    status = StatusOption.query.get_or_404(status_id)
+    db.session.delete(status)
+    db.session.commit()
+    return redirect(url_for("manage_statuses"))
+
+
 with app.app_context():
     db.create_all()
     if not User.query.filter_by(username="admin").first():

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>User Administration</h1>
+<p><a class="App-link" href="{{ url_for('manage_statuses') }}">Manage Statuses</a></p>
 <form action="{{ url_for('create_user') }}" method="post" class="two-column">
 <p><input type="text" name="username" placeholder="Username" required></p>
 <p><input type="password" name="password" placeholder="Password" required></p>

--- a/templates/deals.html
+++ b/templates/deals.html
@@ -3,7 +3,11 @@
     <div class="App">
         <header class="App-header">
             <h1>Deals</h1>
-            <p><a class="App-link" href="{{ url_for('new_deal') }}">Add Deal</a></p>
+            <p>
+                <a class="App-link" href="{{ url_for('new_deal') }}">Add Deal</a>
+                |
+                <a class="App-link" href="{{ url_for('deals_kanban') }}">Kanban View</a>
+            </p>
             <table>
                 <tr><th>Name</th><th>Stage</th><th>Actions</th></tr>
                 {% for deal in deals %}

--- a/templates/leads.html
+++ b/templates/leads.html
@@ -3,7 +3,11 @@
     <div class="App">
         <header class="App-header">
             <h1>Leads</h1>
-            <p><a class="App-link" href="{{ url_for('new_lead') }}">Add Lead</a></p>
+            <p>
+                <a class="App-link" href="{{ url_for('new_lead') }}">Add Lead</a>
+                |
+                <a class="App-link" href="{{ url_for('leads_kanban') }}">Kanban View</a>
+            </p>
             <table>
                 <tr><th>Name</th><th>Status</th><th>Actions</th></tr>
                 {% for lead in leads %}

--- a/templates/statuses.html
+++ b/templates/statuses.html
@@ -1,0 +1,31 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Manage Statuses</h1>
+<p><a class="App-link" href="{{ url_for('admin') }}">Back to Admin</a></p>
+<form action="{{ url_for('create_status') }}" method="post" class="two-column">
+    <p>
+        <input type="text" name="model" placeholder="Model" required>
+    </p>
+    <p>
+        <input type="text" name="value" placeholder="Status" required>
+    </p>
+    <p><button type="submit">Add</button></p>
+</form>
+<table>
+    <tr><th>Model</th><th>Status</th><th>Actions</th></tr>
+    {% for status in statuses %}
+    <tr>
+        <form action="{{ url_for('update_status', status_id=status.id) }}" method="post">
+            <td>{{ status.model }}</td>
+            <td><input type="text" name="value" value="{{ status.value }}"></td>
+            <td>
+                <button type="submit">Update</button>
+        </form>
+        <form action="{{ url_for('delete_status', status_id=status.id) }}" method="post" style="display:inline;">
+                <button type="submit">Delete</button>
+        </form>
+            </td>
+    </tr>
+    {% endfor %}
+</table>
+{% endblock %}

--- a/templates/tasks.html
+++ b/templates/tasks.html
@@ -1,7 +1,11 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Tasks</h1>
-<p><a class="App-link" href="{{ url_for('dashboard') }}">Back to Dashboard</a></p>
+<p>
+    <a class="App-link" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
+    |
+    <a class="App-link" href="{{ url_for('tasks_kanban') }}">Kanban View</a>
+</p>
 <table>
 <tr><th>Description</th><th>Due</th><th>Status</th><th>Model</th><th>Record</th></tr>
 {% for task in tasks %}


### PR DESCRIPTION
## Summary
- add a page for editing StatusOptions in the admin area
- include link to manage statuses from admin page
- add kanban view links to leads, deals, and tasks list pages
- keep logout route in app

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846b732c27483309f777b04d6ed2087