### PR TITLE
Implement search lookups in forms

### DIFF
--- a/templates/edit_contact.html
+++ b/templates/edit_contact.html
@@ -6,13 +6,9 @@
 <p><input type="email" name="email" value="{{ contact.email }}"></p>
 <p><input type="text" name="phone" value="{{ contact.phone }}"></p>
 <p><input type="text" name="title" value="{{ contact.title }}"></p>
+{% from 'macros.html' import lookup %}
 <p>
-<select name="account_id">
-<option value="">-- Account --</option>
-{% for account in accounts %}
-<option value="{{ account.id }}" {% if contact.account_id==account.id %}selected{% endif %}>{{ account.name }}</option>
-{% endfor %}
-</select>
+    {{ lookup('account_id', accounts, 'name', contact.account_id) }}
 </p>
 <p><button type="submit">Update</button></p>
 </form>

--- a/templates/edit_deal.html
+++ b/templates/edit_deal.html
@@ -12,13 +12,9 @@
     </select>
 </p>
 <p><input type="date" name="close_date" value="{{ deal.close_date }}"></p>
+{% from 'macros.html' import lookup %}
 <p>
-<select name="account_id">
-<option value="">-- Account --</option>
-{% for account in accounts %}
-<option value="{{ account.id }}" {% if deal.account_id==account.id %}selected{% endif %}>{{ account.name }}</option>
-{% endfor %}
-</select>
+    {{ lookup('account_id', accounts, 'name', deal.account_id) }}
 </p>
 <p><button type="submit">Update</button></p>
 </form>

--- a/templates/edit_pricebook_entry.html
+++ b/templates/edit_pricebook_entry.html
@@ -2,19 +2,12 @@
 {% block content %}
 <h1>Edit Price Book Entry</h1>
 <form action="{{ url_for('update_pricebook_entry', entry_id=entry.id) }}" method="post">
+{% from 'macros.html' import lookup %}
 <p>
-<select name="product_id">
-{% for product in products %}
-<option value="{{ product.id }}" {% if entry.product_id==product.id %}selected{% endif %}>{{ product.name }}</option>
-{% endfor %}
-</select>
+    {{ lookup('product_id', products, 'name', entry.product_id) }}
 </p>
 <p>
-<select name="pricebook_id">
-{% for pricebook in pricebooks %}
-<option value="{{ pricebook.id }}" {% if entry.pricebook_id==pricebook.id %}selected{% endif %}>{{ pricebook.name }}</option>
-{% endfor %}
-</select>
+    {{ lookup('pricebook_id', pricebooks, 'name', entry.pricebook_id) }}
 </p>
 <p><input type="number" step="0.01" name="unit_price" value="{{ entry.unit_price }}"></p>
 <p><button type="submit">Update</button></p>

--- a/templates/edit_quote.html
+++ b/templates/edit_quote.html
@@ -2,12 +2,9 @@
 {% block content %}
 <h1>Edit Quote</h1>
 <form action="{{ url_for('update_quote', quote_id=quote.id) }}" method="post" class="two-column">
+{% from 'macros.html' import lookup %}
 <p>
-<select name="deal_id">
-{% for deal in deals %}
-<option value="{{ deal.id }}" {% if quote.deal_id==deal.id %}selected{% endif %}>{{ deal.name }}</option>
-{% endfor %}
-</select>
+    {{ lookup('deal_id', deals, 'name', quote.deal_id) }}
 </p>
 <p><input type="number" step="0.01" name="total" value="{{ quote.total }}"></p>
 <p><input type="date" name="expiration_date" value="{{ quote.expiration_date }}"></p>

--- a/templates/edit_quote_line_item.html
+++ b/templates/edit_quote_line_item.html
@@ -2,19 +2,12 @@
 {% block content %}
 <h1>Edit Quote Line Item</h1>
 <form action="{{ url_for('update_quote_line_item', item_id=item.id) }}" method="post">
+{% from 'macros.html' import lookup %}
 <p>
-<select name="quote_id">
-{% for quote in quotes %}
-<option value="{{ quote.id }}" {% if item.quote_id==quote.id %}selected{% endif %}>Quote {{ quote.id }}</option>
-{% endfor %}
-</select>
+    {{ lookup('quote_id', quotes, '', item.quote_id, 'Quote ') }}
 </p>
 <p>
-<select name="product_id">
-{% for product in products %}
-<option value="{{ product.id }}" {% if item.product_id==product.id %}selected{% endif %}>{{ product.name }}</option>
-{% endfor %}
-</select>
+    {{ lookup('product_id', products, 'name', item.product_id) }}
 </p>
 <p><input type="number" name="quantity" value="{{ item.quantity }}"></p>
 <p><input type="number" step="0.01" name="price" value="{{ item.price }}"></p>

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -1,0 +1,9 @@
+{% macro lookup(name, records, attr='name', value='', prefix='') %}
+<input type="text" name="{{ name }}" list="list-{{ name }}" value="{{ value }}" class="form-control" placeholder="Search...">
+<datalist id="list-{{ name }}">
+    <option value=""></option>
+    {% for record in records %}
+        <option value="{{ record.id }}" label="{{ prefix }}{{ record|attr(attr) if attr else record.id }}"></option>
+    {% endfor %}
+</datalist>
+{% endmacro %}

--- a/templates/new_contact.html
+++ b/templates/new_contact.html
@@ -8,13 +8,9 @@
                 <p><input type="email" name="email" placeholder="Email"></p>
                 <p><input type="text" name="phone" placeholder="Phone"></p>
                 <p><input type="text" name="title" placeholder="Title"></p>
+                {% from 'macros.html' import lookup %}
                 <p>
-                    <select name="account_id">
-                        <option value="">-- Account --</option>
-                        {% for account in accounts %}
-                            <option value="{{ account.id }}">{{ account.name }}</option>
-                        {% endfor %}
-                    </select>
+                    {{ lookup('account_id', accounts, 'name') }}
                 </p>
                 <p><button type="submit">Create</button></p>
             </form>

--- a/templates/new_deal.html
+++ b/templates/new_deal.html
@@ -14,13 +14,9 @@
                     </select>
                 </p>
                 <p><input type="date" name="close_date"></p>
+                {% from 'macros.html' import lookup %}
                 <p>
-                    <select name="account_id">
-                        <option value="">-- Account --</option>
-                        {% for account in accounts %}
-                            <option value="{{ account.id }}">{{ account.name }}</option>
-                        {% endfor %}
-                    </select>
+                    {{ lookup('account_id', accounts, 'name') }}
                 </p>
                 <p><button type="submit">Create</button></p>
             </form>

--- a/templates/new_pricebook_entry.html
+++ b/templates/new_pricebook_entry.html
@@ -4,19 +4,12 @@
         <header class="App-header">
             <h1>New Price Book Entry</h1>
             <form action="{{ url_for('create_pricebook_entry') }}" method="post">
+                {% from 'macros.html' import lookup %}
                 <p>
-                    <select name="product_id">
-                        {% for product in products %}
-                            <option value="{{ product.id }}">{{ product.name }}</option>
-                        {% endfor %}
-                    </select>
+                    {{ lookup('product_id', products, 'name') }}
                 </p>
                 <p>
-                    <select name="pricebook_id">
-                        {% for pricebook in pricebooks %}
-                            <option value="{{ pricebook.id }}">{{ pricebook.name }}</option>
-                        {% endfor %}
-                    </select>
+                    {{ lookup('pricebook_id', pricebooks, 'name') }}
                 </p>
                 <p><input type="number" step="0.01" name="unit_price" placeholder="Unit Price"></p>
                 <p><button type="submit">Create</button></p>

--- a/templates/new_quote.html
+++ b/templates/new_quote.html
@@ -4,12 +4,9 @@
         <header class="App-header">
             <h1>New Quote</h1>
             <form action="{{ url_for('create_quote') }}" method="post" class="two-column">
+                {% from 'macros.html' import lookup %}
                 <p>
-                    <select name="deal_id">
-                        {% for deal in deals %}
-                            <option value="{{ deal.id }}">{{ deal.name }}</option>
-                        {% endfor %}
-                    </select>
+                    {{ lookup('deal_id', deals, 'name') }}
                 </p>
                 <p><input type="number" step="0.01" name="total" placeholder="Total"></p>
                 <p><input type="date" name="expiration_date" placeholder="Expiration"></p>

--- a/templates/new_quote_line_item.html
+++ b/templates/new_quote_line_item.html
@@ -4,19 +4,12 @@
         <header class="App-header">
             <h1>New Quote Line Item</h1>
             <form action="{{ url_for('create_quote_line_item') }}" method="post">
+                {% from 'macros.html' import lookup %}
                 <p>
-                    <select name="quote_id">
-                        {% for quote in quotes %}
-                            <option value="{{ quote.id }}">Quote {{ quote.id }}</option>
-                        {% endfor %}
-                    </select>
+                    {{ lookup('quote_id', quotes, '', '', 'Quote ') }}
                 </p>
                 <p>
-                    <select name="product_id">
-                        {% for product in products %}
-                            <option value="{{ product.id }}">{{ product.name }}</option>
-                        {% endfor %}
-                    </select>
+                    {{ lookup('product_id', products, 'name') }}
                 </p>
                 <p><input type="number" name="quantity" placeholder="Quantity" value="1"></p>
                 <p><input type="number" step="0.01" name="price" placeholder="Price"></p>


### PR DESCRIPTION
## Summary
- create `lookup` macro to render datalist search fields
- use the lookup macro for account, deal, product, pricebook and quote selections

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68470207bed48330b1399dd74c24e3bf