### PR TITLE
Fix Kanban status updates for tasks

### DIFF
--- a/app.py
+++ b/app.py
@@ -861,7 +861,7 @@ def tasks_kanban():
     statuses = [s.value for s in StatusOption.query.filter_by(model="task").all()]
     columns = {s: Task.query.filter_by(status=s).all() for s in statuses}
     return render_template(
-        "kanban.html", columns=columns, title="Tasks Kanban"
+        "kanban.html", columns=columns, title="Tasks Kanban", model="task"
     )
 
 
@@ -1038,6 +1038,10 @@ def api_update_status():
         record = Deal.query.get(record_id)
         if record:
             record.stage = status
+    elif model == "task":
+        record = Task.query.get(record_id)
+        if record:
+            record.status = status
     else:
         return {"success": False}, 400
     db.session.commit()


### PR DESCRIPTION
## Summary
- wire up task model to kanban view
- handle task model in the `/api/update_status` API

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6847046d97608330a2a1e6310cb20f1b