### PR TITLE
Improve navigation and kanban view

### DIFF
--- a/app.py
+++ b/app.py
@@ -177,8 +177,12 @@ class Task(db.Model):
 
 @app.before_request
 def require_login():
-    if request.endpoint not in ("login", "static") and not current_user.is_authenticated:
+    if (
+        request.endpoint not in ("login", "static")
+        and not current_user.is_authenticated
+    ):
         return redirect(url_for("login"))
+
 
 @app.route("/")
 def dashboard():
@@ -195,8 +199,6 @@ def dashboard():
     return render_template(
         "dashboard.html", counts=counts, tasks=tasks, title="Dashboard"
     )
-
-
 
 
 @app.route("/leads")
@@ -346,9 +348,7 @@ def show_account(account_id):
 @app.route("/accounts/<int:account_id>/edit")
 def edit_account(account_id):
     account = Account.query.get_or_404(account_id)
-    return render_template(
-        "edit_account.html", account=account, title="Edit Account"
-    )
+    return render_template("edit_account.html", account=account, title="Edit Account")
 
 
 @app.route("/accounts/<int:account_id>/update", methods=["POST"])
@@ -551,9 +551,7 @@ def show_product(product_id):
 @app.route("/products/<int:product_id>/edit")
 def edit_product(product_id):
     product = Product.query.get_or_404(product_id)
-    return render_template(
-        "edit_product.html", product=product, title="Edit Product"
-    )
+    return render_template("edit_product.html", product=product, title="Edit Product")
 
 
 @app.route("/products/<int:product_id>/update", methods=["POST"])
@@ -751,7 +749,9 @@ def show_quote(quote_id):
 def edit_quote(quote_id):
     quote = Quote.query.get_or_404(quote_id)
     deals = Deal.query.all()
-    return render_template("edit_quote.html", quote=quote, deals=deals, title="Edit Quote")
+    return render_template(
+        "edit_quote.html", quote=quote, deals=deals, title="Edit Quote"
+    )
 
 
 @app.route("/quotes/<int:quote_id>/update", methods=["POST"])
@@ -896,7 +896,10 @@ def global_search():
     q = request.args.get("q", "")
     like = f"%{q}%"
     results = {
-        "leads": [(l.name, url_for("show_lead", lead_id=l.id)) for l in Lead.query.filter(Lead.name.ilike(like)).all()],
+        "leads": [
+            (l.name, url_for("show_lead", lead_id=l.id))
+            for l in Lead.query.filter(Lead.name.ilike(like)).all()
+        ],
         "accounts": [
             (a.name, url_for("show_account", account_id=a.id))
             for a in Account.query.filter(Account.name.ilike(like)).all()
@@ -960,7 +963,6 @@ def admin_overview():
     )
 
 
-
 @app.route("/admin/users")
 @login_required
 def admin_users():
@@ -973,7 +975,6 @@ def admin_users():
         users=users,
         title=get_translations().get("user_management", "User Management"),
     )
-
 
 
 @app.route("/admin/users/create", methods=["POST"])
@@ -1069,6 +1070,30 @@ def api_update_status():
         return {"success": False}, 400
     db.session.commit()
     return {"success": True}
+
+
+@app.route("/api/record/<model>/<int:record_id>")
+def api_get_record(model, record_id):
+    if model == "lead":
+        record = Lead.query.get_or_404(record_id)
+    elif model == "account":
+        record = Account.query.get_or_404(record_id)
+    elif model == "contact":
+        record = Contact.query.get_or_404(record_id)
+    elif model == "deal":
+        record = Deal.query.get_or_404(record_id)
+    elif model == "product":
+        record = Product.query.get_or_404(record_id)
+    elif model == "pricebook":
+        record = Pricebook.query.get_or_404(record_id)
+    elif model == "quote":
+        record = Quote.query.get_or_404(record_id)
+    elif model == "task":
+        record = Task.query.get_or_404(record_id)
+    else:
+        return {"error": "model"}, 404
+    data = {k: v for k, v in record.__dict__.items() if k != "_sa_instance_state"}
+    return data
 
 
 with app.app_context():

--- a/static/main.css
+++ b/static/main.css
@@ -62,6 +62,12 @@ code {
     color: white;
     text-decoration: none;
 }
+.navbar .btn {
+    color: white;
+}
+.navbar .btn:hover {
+    color: #fff;
+}
 .content {
     padding: 1rem;
 }
@@ -106,3 +112,7 @@ th {
 
 input, select, textarea { color: #000; }
 .kanban-card { cursor: move; }
+
+.offcanvas-end {
+    width: 400px;
+}

--- a/static/main.css
+++ b/static/main.css
@@ -62,12 +62,6 @@ code {
     color: white;
     text-decoration: none;
 }
-.navbar .btn {
-    color: white;
-}
-.navbar .btn:hover {
-    color: #fff;
-}
 .content {
     padding: 1rem;
 }

--- a/static/main.js
+++ b/static/main.js
@@ -13,11 +13,36 @@ window.addEventListener('DOMContentLoaded', () => {
         });
     });
 
-    // Drag & drop for kanban cards
+    // Drag & drop for kanban cards and detail popup
+    let dragging = false;
     document.querySelectorAll('.kanban-card').forEach(card => {
         card.addEventListener('dragstart', ev => {
+            dragging = true;
             ev.dataTransfer.setData('text/plain', card.dataset.id);
             ev.dataTransfer.setData('text/model', card.dataset.model);
+        });
+        card.addEventListener('dragend', () => { dragging = false; });
+        card.addEventListener('click', () => {
+            if (dragging) { dragging = false; return; }
+            const id = card.dataset.id;
+            const model = card.dataset.model;
+            fetch(`/api/record/${model}/${id}`).then(r => r.json()).then(data => {
+                const body = document.getElementById('recordOffcanvasBody');
+                const label = document.getElementById('recordOffcanvasLabel');
+                if (label) label.textContent = data.name || `${model} ${id}`;
+                if (body) {
+                    body.innerHTML = '';
+                    Object.entries(data).forEach(([k, v]) => {
+                        if (k === '_sa_instance_state' || v === null) return;
+                        const p = document.createElement('p');
+                        p.innerHTML = `<strong>${k}:</strong> ${v}`;
+                        body.appendChild(p);
+                    });
+                }
+                const el = document.getElementById('recordOffcanvas');
+                const offcanvas = bootstrap.Offcanvas.getOrCreateInstance(el);
+                offcanvas.show();
+            });
         });
     });
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,7 @@
 <head>
     <title>{{ title }}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-pIVpG4rxYFIFzu2PYU48X0xiqP/d9vywgq6Z9erjRzCQXDpUe1koRaSPo6e7i0rGUNShUMHbOWcZH/5Li3YlPA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='main.css') }}">
 </head>
 <body>
@@ -15,14 +15,14 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-                    <li class="nav-item"><a class="btn btn-outline-light me-1" href="{{ url_for('list_leads') }}" title="{{ _('leads') }}"><i class="fa-solid fa-address-card"></i></a></li>
-                    <li class="nav-item"><a class="btn btn-outline-light me-1" href="{{ url_for('list_accounts') }}" title="{{ _('accounts') }}"><i class="fa-solid fa-building"></i></a></li>
-                    <li class="nav-item"><a class="btn btn-outline-light me-1" href="{{ url_for('list_contacts') }}" title="{{ _('contacts') }}"><i class="fa-solid fa-user"></i></a></li>
-                    <li class="nav-item"><a class="btn btn-outline-light me-1" href="{{ url_for('list_deals') }}" title="{{ _('deals') }}"><i class="fa-solid fa-handshake"></i></a></li>
-                    <li class="nav-item"><a class="btn btn-outline-light me-1" href="{{ url_for('list_products') }}" title="{{ _('products') }}"><i class="fa-solid fa-box"></i></a></li>
-                    <li class="nav-item"><a class="btn btn-outline-light me-1" href="{{ url_for('list_pricebooks') }}" title="{{ _('pricebooks') }}"><i class="fa-solid fa-book"></i></a></li>
-                    <li class="nav-item"><a class="btn btn-outline-light me-1" href="{{ url_for('list_quotes') }}" title="{{ _('quotes') }}"><i class="fa-solid fa-file-invoice"></i></a></li>
-                    <li class="nav-item"><a class="btn btn-outline-light me-1" href="{{ url_for('list_tasks') }}" title="{{ _('tasks') }}"><i class="fa-solid fa-list"></i></a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('list_leads') }}"><i class="bi bi-person-vcard"></i> {{ _('leads') }}</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('list_accounts') }}"><i class="bi bi-building"></i> {{ _('accounts') }}</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('list_contacts') }}"><i class="bi bi-person"></i> {{ _('contacts') }}</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('list_deals') }}"><i class="bi bi-handshake"></i> {{ _('deals') }}</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('list_products') }}"><i class="bi bi-box"></i> {{ _('products') }}</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('list_pricebooks') }}"><i class="bi bi-book"></i> {{ _('pricebooks') }}</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('list_quotes') }}"><i class="bi bi-file-earmark-text"></i> {{ _('quotes') }}</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('list_tasks') }}"><i class="bi bi-list-task"></i> {{ _('tasks') }}</a></li>
                 </ul>
                 <form class="d-flex" action="{{ url_for('global_search') }}" method="get">
                     <input class="form-control form-control-sm me-2" type="search" placeholder="{{ _('search') }}" name="q">
@@ -30,12 +30,12 @@
                 <ul class="navbar-nav">
                     {% if current_user.is_authenticated %}
                         {% if current_user.is_admin %}
-                            <li class="nav-item"><a class="btn btn-outline-light me-1" href="{{ url_for('admin_overview') }}" title="Admin"><i class="fa-solid fa-gear"></i></a></li>
+                            <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_overview') }}"><i class="bi bi-gear"></i> Admin</a></li>
                         {% endif %}
-                        <li class="nav-item"><a class="btn btn-outline-light me-1" href="{{ url_for('settings') }}" title="{{ _('settings') }}"><i class="fa-solid fa-language"></i></a></li>
-                        <li class="nav-item"><a class="btn btn-outline-light" href="{{ url_for('logout') }}" title="Logout"><i class="fa-solid fa-right-from-bracket"></i></a></li>
+                        <li class="nav-item"><a class="nav-link" href="{{ url_for('settings') }}"><i class="bi bi-translate"></i> {{ _('settings') }}</a></li>
+                        <li class="nav-item"><a class="nav-link" href="{{ url_for('logout') }}"><i class="bi bi-box-arrow-right"></i> Logout</a></li>
                     {% else %}
-                        <li class="nav-item"><a class="btn btn-outline-light" href="{{ url_for('login') }}" title="Login"><i class="fa-solid fa-right-to-bracket"></i></a></li>
+                        <li class="nav-item"><a class="nav-link" href="{{ url_for('login') }}"><i class="bi bi-box-arrow-in-right"></i> Login</a></li>
                     {% endif %}
                 </ul>
             </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,14 +15,14 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('list_leads') }}"><i class="fa-solid fa-address-card"></i> {{ _('leads') }}</a></li>
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('list_accounts') }}"><i class="fa-solid fa-building"></i> {{ _('accounts') }}</a></li>
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('list_contacts') }}"><i class="fa-solid fa-user"></i> {{ _('contacts') }}</a></li>
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('list_deals') }}"><i class="fa-solid fa-handshake"></i> {{ _('deals') }}</a></li>
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('list_products') }}"><i class="fa-solid fa-box"></i> {{ _('products') }}</a></li>
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('list_pricebooks') }}"><i class="fa-solid fa-book"></i> {{ _('pricebooks') }}</a></li>
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('list_quotes') }}"><i class="fa-solid fa-file-invoice"></i> {{ _('quotes') }}</a></li>
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('list_tasks') }}"><i class="fa-solid fa-list"></i> {{ _('tasks') }}</a></li>
+                    <li class="nav-item"><a class="btn btn-outline-light me-1" href="{{ url_for('list_leads') }}" title="{{ _('leads') }}"><i class="fa-solid fa-address-card"></i></a></li>
+                    <li class="nav-item"><a class="btn btn-outline-light me-1" href="{{ url_for('list_accounts') }}" title="{{ _('accounts') }}"><i class="fa-solid fa-building"></i></a></li>
+                    <li class="nav-item"><a class="btn btn-outline-light me-1" href="{{ url_for('list_contacts') }}" title="{{ _('contacts') }}"><i class="fa-solid fa-user"></i></a></li>
+                    <li class="nav-item"><a class="btn btn-outline-light me-1" href="{{ url_for('list_deals') }}" title="{{ _('deals') }}"><i class="fa-solid fa-handshake"></i></a></li>
+                    <li class="nav-item"><a class="btn btn-outline-light me-1" href="{{ url_for('list_products') }}" title="{{ _('products') }}"><i class="fa-solid fa-box"></i></a></li>
+                    <li class="nav-item"><a class="btn btn-outline-light me-1" href="{{ url_for('list_pricebooks') }}" title="{{ _('pricebooks') }}"><i class="fa-solid fa-book"></i></a></li>
+                    <li class="nav-item"><a class="btn btn-outline-light me-1" href="{{ url_for('list_quotes') }}" title="{{ _('quotes') }}"><i class="fa-solid fa-file-invoice"></i></a></li>
+                    <li class="nav-item"><a class="btn btn-outline-light me-1" href="{{ url_for('list_tasks') }}" title="{{ _('tasks') }}"><i class="fa-solid fa-list"></i></a></li>
                 </ul>
                 <form class="d-flex" action="{{ url_for('global_search') }}" method="get">
                     <input class="form-control form-control-sm me-2" type="search" placeholder="{{ _('search') }}" name="q">
@@ -30,12 +30,12 @@
                 <ul class="navbar-nav">
                     {% if current_user.is_authenticated %}
                         {% if current_user.is_admin %}
-                            <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_overview') }}"><i class="fa-solid fa-gear"></i> Admin</a></li>
+                            <li class="nav-item"><a class="btn btn-outline-light me-1" href="{{ url_for('admin_overview') }}" title="Admin"><i class="fa-solid fa-gear"></i></a></li>
                         {% endif %}
-                        <li class="nav-item"><a class="nav-link" href="{{ url_for('settings') }}"><i class="fa-solid fa-language"></i> {{ _('settings') }}</a></li>
-                        <li class="nav-item"><a class="nav-link" href="{{ url_for('logout') }}"><i class="fa-solid fa-right-from-bracket"></i> Logout</a></li>
+                        <li class="nav-item"><a class="btn btn-outline-light me-1" href="{{ url_for('settings') }}" title="{{ _('settings') }}"><i class="fa-solid fa-language"></i></a></li>
+                        <li class="nav-item"><a class="btn btn-outline-light" href="{{ url_for('logout') }}" title="Logout"><i class="fa-solid fa-right-from-bracket"></i></a></li>
                     {% else %}
-                        <li class="nav-item"><a class="nav-link" href="{{ url_for('login') }}"><i class="fa-solid fa-right-to-bracket"></i> Login</a></li>
+                        <li class="nav-item"><a class="btn btn-outline-light" href="{{ url_for('login') }}" title="Login"><i class="fa-solid fa-right-to-bracket"></i></a></li>
                     {% endif %}
                 </ul>
             </div>

--- a/templates/kanban.html
+++ b/templates/kanban.html
@@ -10,8 +10,13 @@
             <div class="card mb-2 kanban-card" draggable="true" data-id="{{ r.id }}" data-model="{{ model }}">
                 <div class="card-body p-2">
                     <h5 class="card-title">{{ r.name if r.name else r.description }}</h5>
-                    {% if r.email %}<p class="card-text small">{{ r.email }}</p>{% endif %}
-                    {% if r.company %}<p class="card-text small">{{ r.company }}</p>{% endif %}
+                    {% set ns = namespace(count=0) %}
+                    {% for key, val in r.__dict__.items() %}
+                        {% if key not in ['_sa_instance_state', 'name', 'id', 'notes'] and val and ns.count < 5 %}
+                            <p class="card-text small"><strong>{{ key.replace('_',' ').title() }}:</strong> {{ val }}</p>
+                            {% set ns.count = ns.count + 1 %}
+                        {% endif %}
+                    {% endfor %}
                 </div>
             </div>
         {% else %}
@@ -20,5 +25,14 @@
         </div>
     </div>
     {% endfor %}
+</div>
+<div class="offcanvas offcanvas-end" tabindex="-1" id="recordOffcanvas" aria-labelledby="recordOffcanvasLabel">
+    <div class="offcanvas-header">
+        <h5 id="recordOffcanvasLabel" class="offcanvas-title">Details</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+    </div>
+    <div class="offcanvas-body" id="recordOffcanvasBody">
+        Loading...
+    </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- revamp nav bar with button-style icons
- show up to 5 fields on kanban cards
- add side offcanvas to show record details
- enable popup details via JS fetch
- provide API endpoint for record JSON

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6847078ac9d083308019129906de2317