### PR TITLE
Improve dashboard cards and record navigation

### DIFF
--- a/app.py
+++ b/app.py
@@ -186,6 +186,7 @@ def require_login():
 
 @app.route("/")
 def dashboard():
+    q = request.args.get("q", "")
     counts = {
         "leads": Lead.query.count(),
         "accounts": Account.query.count(),
@@ -195,9 +196,12 @@ def dashboard():
         "pricebooks": Pricebook.query.count(),
         "quotes": Quote.query.count(),
     }
-    tasks = Task.query.all()
+    query = Task.query
+    if q:
+        query = query.filter(Task.description.ilike(f"%{q}%"))
+    tasks = query.all()
     return render_template(
-        "dashboard.html", counts=counts, tasks=tasks, title="Dashboard"
+        "dashboard.html", counts=counts, tasks=tasks, q=q, title="Dashboard"
     )
 
 

--- a/templates/account_detail.html
+++ b/templates/account_detail.html
@@ -1,19 +1,31 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>{{ account.name }}</h1>
-<p>Industry: {{ account.industry }}</p>
-<p>Email: {{ account.email }}</p>
-<p>Phone: {{ account.phone }}</p>
-<p>Address: {{ account.address }}</p>
-<p>Notes: {{ account.notes }}</p>
-<p><a class="App-link" href="{{ url_for('edit_account', account_id=account.id) }}">Edit</a></p>
-<p><a class="App-link" href="{{ url_for('new_task', model='accounts', record_id=account.id) }}">Add Task</a></p>
-<h2>Tasks</h2>
-<ul>
-{% for task in tasks %}
-<li>{{ task.description }} ({{ task.due_date }})</li>
-{% else %}
-<li>No tasks found.</li>
-{% endfor %}
-</ul>
+<div class="row">
+    <div class="col-md-3">
+        <div class="sticky-top pt-3">
+            <h5>Related Lists</h5>
+            <ul class="nav flex-column related-nav">
+                <li class="nav-item"><a class="nav-link" href="#tasks">Tasks ({{ tasks|length }})</a></li>
+            </ul>
+        </div>
+    </div>
+    <div class="col-md-9">
+        <h1>{{ account.name }}</h1>
+        <p>Industry: {{ account.industry }}</p>
+        <p>Email: {{ account.email }}</p>
+        <p>Phone: {{ account.phone }}</p>
+        <p>Address: {{ account.address }}</p>
+        <p>Notes: {{ account.notes }}</p>
+        <p><a class="App-link" href="{{ url_for('edit_account', account_id=account.id) }}">Edit</a></p>
+        <p><a class="App-link" href="{{ url_for('new_task', model='accounts', record_id=account.id) }}">Add Task</a></p>
+        <h2 id="tasks">Tasks</h2>
+        <ul class="list-group mb-3">
+        {% for task in tasks %}
+        <li class="list-group-item">{{ task.description }} ({{ task.due_date }})</li>
+        {% else %}
+        <li class="list-group-item">No tasks found.</li>
+        {% endfor %}
+        </ul>
+    </div>
+</div>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -42,7 +42,17 @@
         </div>
     </nav>
     <div class="container py-4">
-        {% block content %}{% endblock %}
+        {% block container_content %}
+        <div class="row justify-content-center">
+            <div class="col-lg-10">
+                <div class="card">
+                    <div class="card-body">
+                        {% block content %}{% endblock %}
+                    </div>
+                </div>
+            </div>
+        </div>
+        {% endblock %}
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="{{ url_for('static', filename='main.js') }}"></script>

--- a/templates/contact_detail.html
+++ b/templates/contact_detail.html
@@ -1,18 +1,30 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>{{ contact.name }}</h1>
-<p>Email: {{ contact.email }}</p>
-<p>Phone: {{ contact.phone }}</p>
-<p>Title: {{ contact.title }}</p>
-<p>Account: {{ contact.account.name if contact.account else '' }}</p>
-<p><a class="App-link" href="{{ url_for('edit_contact', contact_id=contact.id) }}">Edit</a></p>
-<p><a class="App-link" href="{{ url_for('new_task', model='contacts', record_id=contact.id) }}">Add Task</a></p>
-<h2>Tasks</h2>
-<ul>
-{% for task in tasks %}
-<li>{{ task.description }} ({{ task.due_date }})</li>
-{% else %}
-<li>No tasks found.</li>
-{% endfor %}
-</ul>
+<div class="row">
+    <div class="col-md-3">
+        <div class="sticky-top pt-3">
+            <h5>Related Lists</h5>
+            <ul class="nav flex-column related-nav">
+                <li class="nav-item"><a class="nav-link" href="#tasks">Tasks ({{ tasks|length }})</a></li>
+            </ul>
+        </div>
+    </div>
+    <div class="col-md-9">
+        <h1>{{ contact.name }}</h1>
+        <p>Email: {{ contact.email }}</p>
+        <p>Phone: {{ contact.phone }}</p>
+        <p>Title: {{ contact.title }}</p>
+        <p>Account: {{ contact.account.name if contact.account else '' }}</p>
+        <p><a class="App-link" href="{{ url_for('edit_contact', contact_id=contact.id) }}">Edit</a></p>
+        <p><a class="App-link" href="{{ url_for('new_task', model='contacts', record_id=contact.id) }}">Add Task</a></p>
+        <h2 id="tasks">Tasks</h2>
+        <ul class="list-group mb-3">
+        {% for task in tasks %}
+        <li class="list-group-item">{{ task.description }} ({{ task.due_date }})</li>
+        {% else %}
+        <li class="list-group-item">No tasks found.</li>
+        {% endfor %}
+        </ul>
+    </div>
+</div>
 {% endblock %}

--- a/templates/customer_detail.html
+++ b/templates/customer_detail.html
@@ -1,17 +1,29 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>{{ customer.name }}</h1>
-<p>Email: {{ customer.email }}</p>
-<p>Phone: {{ customer.phone }}</p>
-<p>Notes: {{ customer.notes }}</p>
-<p><a class="App-link" href="{{ url_for('edit_customer', customer_id=customer.id) }}">Edit</a></p>
-<p><a class="App-link" href="{{ url_for('new_task', model='customers', record_id=customer.id) }}">Add Task</a></p>
-<h2>Tasks</h2>
-<ul>
-{% for task in tasks %}
-<li>{{ task.description }} ({{ task.due_date }})</li>
-{% else %}
-<li>No tasks found.</li>
-{% endfor %}
-</ul>
+<div class="row">
+    <div class="col-md-3">
+        <div class="sticky-top pt-3">
+            <h5>Related Lists</h5>
+            <ul class="nav flex-column related-nav">
+                <li class="nav-item"><a class="nav-link" href="#tasks">Tasks ({{ tasks|length }})</a></li>
+            </ul>
+        </div>
+    </div>
+    <div class="col-md-9">
+        <h1>{{ customer.name }}</h1>
+        <p>Email: {{ customer.email }}</p>
+        <p>Phone: {{ customer.phone }}</p>
+        <p>Notes: {{ customer.notes }}</p>
+        <p><a class="App-link" href="{{ url_for('edit_customer', customer_id=customer.id) }}">Edit</a></p>
+        <p><a class="App-link" href="{{ url_for('new_task', model='customers', record_id=customer.id) }}">Add Task</a></p>
+        <h2 id="tasks">Tasks</h2>
+        <ul class="list-group mb-3">
+        {% for task in tasks %}
+        <li class="list-group-item">{{ task.description }} ({{ task.due_date }})</li>
+        {% else %}
+        <li class="list-group-item">No tasks found.</li>
+        {% endfor %}
+        </ul>
+    </div>
+</div>
 {% endblock %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,19 +1,41 @@
 {% extends 'base.html' %}
-{% block content %}
+{% block container_content %}
 <h1>Dashboard</h1>
-<div class="two-column">
-    <div>
-        <canvas id="countChart"></canvas>
+<div class="row">
+    <div class="col-lg-6 mb-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <canvas id="countChart"></canvas>
+            </div>
+        </div>
     </div>
-    <div>
-        <h2>Tasks</h2>
-        <ul>
-        {% for task in tasks %}
-            <li>{{ task.description }} ({{ task.status }})</li>
-        {% else %}
-            <li>No tasks</li>
-        {% endfor %}
-        </ul>
+    <div class="col-lg-6 mb-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <h2 class="h5">Tasks</h2>
+                <form method="get" class="mb-2">
+                    <input type="text" class="form-control form-control-sm" name="q" value="{{ q or '' }}" placeholder="{{ _('search') }}">
+                </form>
+                <table class="table table-sm">
+                    <thead>
+                        <tr><th>Description</th><th>Due</th><th>Status</th><th>Model</th><th>Record</th></tr>
+                    </thead>
+                    <tbody>
+                    {% for task in tasks %}
+                        <tr>
+                            <td>{{ task.description }}</td>
+                            <td>{{ task.due_date or '' }}</td>
+                            <td>{{ task.status }}</td>
+                            <td>{{ task.model }}</td>
+                            <td>{{ task.record_id }}</td>
+                        </tr>
+                    {% else %}
+                        <tr><td colspan="5">{{ _('none_found') }}</td></tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
     </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>

--- a/templates/deal_detail.html
+++ b/templates/deal_detail.html
@@ -1,18 +1,30 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>{{ deal.name }}</h1>
-<p>Amount: {{ deal.amount }}</p>
-<p>Stage: {{ deal.stage }}</p>
-<p>Close Date: {{ deal.close_date }}</p>
-<p>Account: {{ deal.account.name if deal.account else '' }}</p>
-<p><a class="App-link" href="{{ url_for('edit_deal', deal_id=deal.id) }}">Edit</a></p>
-<p><a class="App-link" href="{{ url_for('new_task', model='deals', record_id=deal.id) }}">Add Task</a></p>
-<h2>Tasks</h2>
-<ul>
-{% for task in tasks %}
-<li>{{ task.description }} ({{ task.due_date }})</li>
-{% else %}
-<li>No tasks found.</li>
-{% endfor %}
-</ul>
+<div class="row">
+    <div class="col-md-3">
+        <div class="sticky-top pt-3">
+            <h5>Related Lists</h5>
+            <ul class="nav flex-column related-nav">
+                <li class="nav-item"><a class="nav-link" href="#tasks">Tasks ({{ tasks|length }})</a></li>
+            </ul>
+        </div>
+    </div>
+    <div class="col-md-9">
+        <h1>{{ deal.name }}</h1>
+        <p>Amount: {{ deal.amount }}</p>
+        <p>Stage: {{ deal.stage }}</p>
+        <p>Close Date: {{ deal.close_date }}</p>
+        <p>Account: {{ deal.account.name if deal.account else '' }}</p>
+        <p><a class="App-link" href="{{ url_for('edit_deal', deal_id=deal.id) }}">Edit</a></p>
+        <p><a class="App-link" href="{{ url_for('new_task', model='deals', record_id=deal.id) }}">Add Task</a></p>
+        <h2 id="tasks">Tasks</h2>
+        <ul class="list-group mb-3">
+        {% for task in tasks %}
+        <li class="list-group-item">{{ task.description }} ({{ task.due_date }})</li>
+        {% else %}
+        <li class="list-group-item">No tasks found.</li>
+        {% endfor %}
+        </ul>
+    </div>
+</div>
 {% endblock %}

--- a/templates/kanban.html
+++ b/templates/kanban.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% block content %}
+{% block container_content %}
 <h1 class="mb-4">{{ title }}</h1>
 <div class="kanban row">
     {% for status, records in columns.items() %}

--- a/templates/lead_detail.html
+++ b/templates/lead_detail.html
@@ -1,22 +1,34 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>{{ lead.name }}</h1>
-<p>Email: {{ lead.email }}</p>
-<p>Phone: {{ lead.phone }}</p>
-<p>Company: {{ lead.company }}</p>
-<p>Notes: {{ lead.notes }}</p>
-<p>Status: {{ lead.status }}</p>
-<p><a class="App-link" href="{{ url_for('edit_lead', lead_id=lead.id) }}">Edit</a></p>
-<form action="{{ url_for('convert_lead', lead_id=lead.id) }}" method="post" style="display:inline;">
-    <button type="submit">Convert to Account</button>
-</form>
-<p><a class="App-link" href="{{ url_for('new_task', model='leads', record_id=lead.id) }}">Add Task</a></p>
-<h2>Tasks</h2>
-<ul>
-{% for task in tasks %}
-<li>{{ task.description }} ({{ task.due_date }})</li>
-{% else %}
-<li>No tasks found.</li>
-{% endfor %}
-</ul>
+<div class="row">
+    <div class="col-md-3">
+        <div class="sticky-top pt-3">
+            <h5>Related Lists</h5>
+            <ul class="nav flex-column related-nav">
+                <li class="nav-item"><a class="nav-link" href="#tasks">Tasks ({{ tasks|length }})</a></li>
+            </ul>
+        </div>
+    </div>
+    <div class="col-md-9">
+        <h1>{{ lead.name }}</h1>
+        <p>Email: {{ lead.email }}</p>
+        <p>Phone: {{ lead.phone }}</p>
+        <p>Company: {{ lead.company }}</p>
+        <p>Notes: {{ lead.notes }}</p>
+        <p>Status: {{ lead.status }}</p>
+        <p><a class="App-link" href="{{ url_for('edit_lead', lead_id=lead.id) }}">Edit</a></p>
+        <form action="{{ url_for('convert_lead', lead_id=lead.id) }}" method="post" style="display:inline;">
+            <button type="submit">Convert to Account</button>
+        </form>
+        <p><a class="App-link" href="{{ url_for('new_task', model='leads', record_id=lead.id) }}">Add Task</a></p>
+        <h2 id="tasks">Tasks</h2>
+        <ul class="list-group mb-3">
+        {% for task in tasks %}
+        <li class="list-group-item">{{ task.description }} ({{ task.due_date }})</li>
+        {% else %}
+        <li class="list-group-item">No tasks found.</li>
+        {% endfor %}
+        </ul>
+    </div>
+</div>
 {% endblock %}

--- a/templates/pricebook_detail.html
+++ b/templates/pricebook_detail.html
@@ -1,15 +1,27 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>{{ pricebook.name }}</h1>
-<p>Description: {{ pricebook.description }}</p>
-<p><a class="App-link" href="{{ url_for('edit_pricebook', pricebook_id=pricebook.id) }}">Edit</a></p>
-<p><a class="App-link" href="{{ url_for('new_task', model='pricebooks', record_id=pricebook.id) }}">Add Task</a></p>
-<h2>Tasks</h2>
-<ul>
-{% for task in tasks %}
-<li>{{ task.description }} ({{ task.due_date }})</li>
-{% else %}
-<li>No tasks found.</li>
-{% endfor %}
-</ul>
+<div class="row">
+    <div class="col-md-3">
+        <div class="sticky-top pt-3">
+            <h5>Related Lists</h5>
+            <ul class="nav flex-column related-nav">
+                <li class="nav-item"><a class="nav-link" href="#tasks">Tasks ({{ tasks|length }})</a></li>
+            </ul>
+        </div>
+    </div>
+    <div class="col-md-9">
+        <h1>{{ pricebook.name }}</h1>
+        <p>Description: {{ pricebook.description }}</p>
+        <p><a class="App-link" href="{{ url_for('edit_pricebook', pricebook_id=pricebook.id) }}">Edit</a></p>
+        <p><a class="App-link" href="{{ url_for('new_task', model='pricebooks', record_id=pricebook.id) }}">Add Task</a></p>
+        <h2 id="tasks">Tasks</h2>
+        <ul class="list-group mb-3">
+        {% for task in tasks %}
+        <li class="list-group-item">{{ task.description }} ({{ task.due_date }})</li>
+        {% else %}
+        <li class="list-group-item">No tasks found.</li>
+        {% endfor %}
+        </ul>
+    </div>
+</div>
 {% endblock %}

--- a/templates/pricebook_entry_detail.html
+++ b/templates/pricebook_entry_detail.html
@@ -1,17 +1,29 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>Price Book Entry {{ entry.id }}</h1>
-<p>Product: {{ entry.product.name }}</p>
-<p>Pricebook: {{ entry.pricebook.name }}</p>
-<p>Unit Price: {{ entry.unit_price }}</p>
-<p><a class="App-link" href="{{ url_for('edit_pricebook_entry', entry_id=entry.id) }}">Edit</a></p>
-<p><a class="App-link" href="{{ url_for('new_task', model='pricebook_entries', record_id=entry.id) }}">Add Task</a></p>
-<h2>Tasks</h2>
-<ul>
-{% for task in tasks %}
-<li>{{ task.description }} ({{ task.due_date }})</li>
-{% else %}
-<li>No tasks found.</li>
-{% endfor %}
-</ul>
+<div class="row">
+    <div class="col-md-3">
+        <div class="sticky-top pt-3">
+            <h5>Related Lists</h5>
+            <ul class="nav flex-column related-nav">
+                <li class="nav-item"><a class="nav-link" href="#tasks">Tasks ({{ tasks|length }})</a></li>
+            </ul>
+        </div>
+    </div>
+    <div class="col-md-9">
+        <h1>Price Book Entry {{ entry.id }}</h1>
+        <p>Product: {{ entry.product.name }}</p>
+        <p>Pricebook: {{ entry.pricebook.name }}</p>
+        <p>Unit Price: {{ entry.unit_price }}</p>
+        <p><a class="App-link" href="{{ url_for('edit_pricebook_entry', entry_id=entry.id) }}">Edit</a></p>
+        <p><a class="App-link" href="{{ url_for('new_task', model='pricebook_entries', record_id=entry.id) }}">Add Task</a></p>
+        <h2 id="tasks">Tasks</h2>
+        <ul class="list-group mb-3">
+        {% for task in tasks %}
+        <li class="list-group-item">{{ task.description }} ({{ task.due_date }})</li>
+        {% else %}
+        <li class="list-group-item">No tasks found.</li>
+        {% endfor %}
+        </ul>
+    </div>
+</div>
 {% endblock %}

--- a/templates/product_detail.html
+++ b/templates/product_detail.html
@@ -1,16 +1,28 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>{{ product.name }}</h1>
-<p>Price: {{ product.price }}</p>
-<p>Description: {{ product.description }}</p>
-<p><a class="App-link" href="{{ url_for('edit_product', product_id=product.id) }}">Edit</a></p>
-<p><a class="App-link" href="{{ url_for('new_task', model='products', record_id=product.id) }}">Add Task</a></p>
-<h2>Tasks</h2>
-<ul>
-{% for task in tasks %}
-<li>{{ task.description }} ({{ task.due_date }})</li>
-{% else %}
-<li>No tasks found.</li>
-{% endfor %}
-</ul>
+<div class="row">
+    <div class="col-md-3">
+        <div class="sticky-top pt-3">
+            <h5>Related Lists</h5>
+            <ul class="nav flex-column related-nav">
+                <li class="nav-item"><a class="nav-link" href="#tasks">Tasks ({{ tasks|length }})</a></li>
+            </ul>
+        </div>
+    </div>
+    <div class="col-md-9">
+        <h1>{{ product.name }}</h1>
+        <p>Price: {{ product.price }}</p>
+        <p>Description: {{ product.description }}</p>
+        <p><a class="App-link" href="{{ url_for('edit_product', product_id=product.id) }}">Edit</a></p>
+        <p><a class="App-link" href="{{ url_for('new_task', model='products', record_id=product.id) }}">Add Task</a></p>
+        <h2 id="tasks">Tasks</h2>
+        <ul class="list-group mb-3">
+        {% for task in tasks %}
+        <li class="list-group-item">{{ task.description }} ({{ task.due_date }})</li>
+        {% else %}
+        <li class="list-group-item">No tasks found.</li>
+        {% endfor %}
+        </ul>
+    </div>
+</div>
 {% endblock %}

--- a/templates/quote_detail.html
+++ b/templates/quote_detail.html
@@ -1,17 +1,29 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>Quote {{ quote.id }}</h1>
-<p>Deal: {{ quote.deal.name if quote.deal else '' }}</p>
-<p>Total: {{ quote.total }}</p>
-<p>Expiration: {{ quote.expiration_date }}</p>
-<p><a class="App-link" href="{{ url_for('edit_quote', quote_id=quote.id) }}">Edit</a></p>
-<p><a class="App-link" href="{{ url_for('new_task', model='quotes', record_id=quote.id) }}">Add Task</a></p>
-<h2>Tasks</h2>
-<ul>
-{% for task in tasks %}
-<li>{{ task.description }} ({{ task.due_date }})</li>
-{% else %}
-<li>No tasks found.</li>
-{% endfor %}
-</ul>
+<div class="row">
+    <div class="col-md-3">
+        <div class="sticky-top pt-3">
+            <h5>Related Lists</h5>
+            <ul class="nav flex-column related-nav">
+                <li class="nav-item"><a class="nav-link" href="#tasks">Tasks ({{ tasks|length }})</a></li>
+            </ul>
+        </div>
+    </div>
+    <div class="col-md-9">
+        <h1>Quote {{ quote.id }}</h1>
+        <p>Deal: {{ quote.deal.name if quote.deal else '' }}</p>
+        <p>Total: {{ quote.total }}</p>
+        <p>Expiration: {{ quote.expiration_date }}</p>
+        <p><a class="App-link" href="{{ url_for('edit_quote', quote_id=quote.id) }}">Edit</a></p>
+        <p><a class="App-link" href="{{ url_for('new_task', model='quotes', record_id=quote.id) }}">Add Task</a></p>
+        <h2 id="tasks">Tasks</h2>
+        <ul class="list-group mb-3">
+        {% for task in tasks %}
+        <li class="list-group-item">{{ task.description }} ({{ task.due_date }})</li>
+        {% else %}
+        <li class="list-group-item">No tasks found.</li>
+        {% endfor %}
+        </ul>
+    </div>
+</div>
 {% endblock %}

--- a/templates/quote_line_item_detail.html
+++ b/templates/quote_line_item_detail.html
@@ -1,18 +1,30 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>Quote Line Item {{ item.id }}</h1>
-<p>Quote: {{ item.quote.id }}</p>
-<p>Product: {{ item.product.name }}</p>
-<p>Quantity: {{ item.quantity }}</p>
-<p>Price: {{ item.price }}</p>
-<p><a class="App-link" href="{{ url_for('edit_quote_line_item', item_id=item.id) }}">Edit</a></p>
-<p><a class="App-link" href="{{ url_for('new_task', model='quote_line_items', record_id=item.id) }}">Add Task</a></p>
-<h2>Tasks</h2>
-<ul>
-{% for task in tasks %}
-<li>{{ task.description }} ({{ task.due_date }})</li>
-{% else %}
-<li>No tasks found.</li>
-{% endfor %}
-</ul>
+<div class="row">
+    <div class="col-md-3">
+        <div class="sticky-top pt-3">
+            <h5>Related Lists</h5>
+            <ul class="nav flex-column related-nav">
+                <li class="nav-item"><a class="nav-link" href="#tasks">Tasks ({{ tasks|length }})</a></li>
+            </ul>
+        </div>
+    </div>
+    <div class="col-md-9">
+        <h1>Quote Line Item {{ item.id }}</h1>
+        <p>Quote: {{ item.quote.id }}</p>
+        <p>Product: {{ item.product.name }}</p>
+        <p>Quantity: {{ item.quantity }}</p>
+        <p>Price: {{ item.price }}</p>
+        <p><a class="App-link" href="{{ url_for('edit_quote_line_item', item_id=item.id) }}">Edit</a></p>
+        <p><a class="App-link" href="{{ url_for('new_task', model='quote_line_items', record_id=item.id) }}">Add Task</a></p>
+        <h2 id="tasks">Tasks</h2>
+        <ul class="list-group mb-3">
+        {% for task in tasks %}
+        <li class="list-group-item">{{ task.description }} ({{ task.due_date }})</li>
+        {% else %}
+        <li class="list-group-item">No tasks found.</li>
+        {% endfor %}
+        </ul>
+    </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add search capability on dashboard tasks
- wrap dashboard chart and task list in cards
- center content in cards via base template update
- add related lists side navigation to record pages

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68470d6acd4c8330b3c008c14cdd6fdf