### PR TITLE
Add messaging and notifications

### DIFF
--- a/templates/account_detail.html
+++ b/templates/account_detail.html
@@ -26,6 +26,7 @@
         <li class="list-group-item">No tasks found.</li>
         {% endfor %}
         </ul>
+        {% include 'messages_section.html' %}
     </div>
 </div>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,6 +32,7 @@
                         {% if current_user.is_admin %}
                             <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_overview') }}"><i class="bi bi-gear"></i> Admin</a></li>
                         {% endif %}
+                        <li class="nav-item"><a class="nav-link" href="{{ url_for('list_notifications') }}"><i class="bi bi-bell"></i> Notifications{% if unread_notifications %} ({{ unread_notifications }}){% endif %}</a></li>
                         <li class="nav-item"><a class="nav-link" href="{{ url_for('settings') }}"><i class="bi bi-translate"></i> {{ _('settings') }}</a></li>
                         <li class="nav-item"><a class="nav-link" href="{{ url_for('logout') }}"><i class="bi bi-box-arrow-right"></i> Logout</a></li>
                     {% else %}

--- a/templates/contact_detail.html
+++ b/templates/contact_detail.html
@@ -25,6 +25,7 @@
         <li class="list-group-item">No tasks found.</li>
         {% endfor %}
         </ul>
+        {% include 'messages_section.html' %}
     </div>
 </div>
 {% endblock %}

--- a/templates/deal_detail.html
+++ b/templates/deal_detail.html
@@ -25,6 +25,7 @@
         <li class="list-group-item">No tasks found.</li>
         {% endfor %}
         </ul>
+        {% include 'messages_section.html' %}
     </div>
 </div>
 {% endblock %}

--- a/templates/lead_detail.html
+++ b/templates/lead_detail.html
@@ -29,6 +29,7 @@
         <li class="list-group-item">No tasks found.</li>
         {% endfor %}
         </ul>
+        {% include 'messages_section.html' %}
     </div>
 </div>
 {% endblock %}

--- a/templates/messages_section.html
+++ b/templates/messages_section.html
@@ -1,0 +1,25 @@
+<h2 id="messages">Messages</h2>
+<ul class="list-group mb-3">
+{% for m in messages %}
+<li class="list-group-item">
+    <div class="small text-muted">{{ m.user.username }} {{ m.created_at.strftime('%Y-%m-%d %H:%M') }}</div>
+    <div>{{ m.content|safe }}</div>
+</li>
+{% else %}
+<li class="list-group-item">No messages found.</li>
+{% endfor %}
+</ul>
+<form action="{{ url_for('create_message') }}" method="post" class="mb-3">
+    <input type="hidden" name="model" value="{{ model }}">
+    <input type="hidden" name="record_id" value="{{ record_id }}">
+    <textarea id="message-content" name="content" class="form-control" rows="3"></textarea>
+    <button type="submit" class="btn btn-primary mt-2">Send</button>
+</form>
+<script src="https://cdn.jsdelivr.net/npm/@ckeditor/ckeditor5-build-classic@35.4.0/build/ckeditor.js"></script>
+<script>
+  if (window.ClassicEditor) {
+    ClassicEditor.create(document.querySelector('#message-content'), {
+      toolbar: ['bold','italic','underline','bulletedList','numberedList']
+    }).catch(e=>{});
+  }
+</script>

--- a/templates/notifications.html
+++ b/templates/notifications.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Notifications</h1>
+<ul class="list-group">
+{% for n in notifications %}
+<li class="list-group-item{% if not n.is_read %} fw-bold{% endif %}">
+    <a href="{{ url_for('view_notification', notif_id=n.id) }}">
+        {{ n.message.user.username }} mentioned you in {{ n.model }} {{ n.record_id }} - {{ n.created_at.strftime('%Y-%m-%d %H:%M') }}
+    </a>
+</li>
+{% else %}
+<li class="list-group-item">No notifications found.</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/templates/pricebook_detail.html
+++ b/templates/pricebook_detail.html
@@ -22,6 +22,7 @@
         <li class="list-group-item">No tasks found.</li>
         {% endfor %}
         </ul>
+        {% include 'messages_section.html' %}
     </div>
 </div>
 {% endblock %}

--- a/templates/pricebook_entry_detail.html
+++ b/templates/pricebook_entry_detail.html
@@ -24,6 +24,7 @@
         <li class="list-group-item">No tasks found.</li>
         {% endfor %}
         </ul>
+        {% include 'messages_section.html' %}
     </div>
 </div>
 {% endblock %}

--- a/templates/product_detail.html
+++ b/templates/product_detail.html
@@ -23,6 +23,7 @@
         <li class="list-group-item">No tasks found.</li>
         {% endfor %}
         </ul>
+        {% include 'messages_section.html' %}
     </div>
 </div>
 {% endblock %}

--- a/templates/quote_detail.html
+++ b/templates/quote_detail.html
@@ -24,6 +24,7 @@
         <li class="list-group-item">No tasks found.</li>
         {% endfor %}
         </ul>
+        {% include 'messages_section.html' %}
     </div>
 </div>
 {% endblock %}

--- a/templates/quote_line_item_detail.html
+++ b/templates/quote_line_item_detail.html
@@ -25,6 +25,7 @@
         <li class="list-group-item">No tasks found.</li>
         {% endfor %}
         </ul>
+        {% include 'messages_section.html' %}
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- implement Message and Notification models
- show unread notification count in navbar
- add message forms to record detail pages
- allow mentioning users and send notifications
- list notifications and show messages per record

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68473e1b9dc48330a46a93ab0b8b93c0