### PR TITLE
Implement user profiles

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -10,6 +10,21 @@
             {% endfor %}
         </select>
     </div>
+    <div class="mb-3">
+        <label for="timezone" class="form-label">Timezone</label>
+        <input type="text" id="timezone" name="timezone" value="{{ tz }}" class="form-control">
+    </div>
+    <div class="mb-3">
+        <label for="country" class="form-label">Country</label>
+        <input type="text" id="country" name="country" value="{{ country }}" class="form-control">
+    </div>
+    <div class="mb-3">
+        <label for="currency" class="form-label">Currency</label>
+        <select id="currency" name="currency" class="form-select">
+            <option value="USD" {% if currency == 'USD' %}selected{% endif %}>USD</option>
+            <option value="EUR" {% if currency == 'EUR' %}selected{% endif %}>EUR</option>
+        </select>
+    </div>
     <button type="submit" class="btn btn-primary">Save</button>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- expand `User` model with language, timezone, country, and currency
- prefer current user's language for translations
- add profile fields to settings form and persist them
- include profile data when creating the admin user and when adding users
- automatically migrate the user table if profile fields are missing

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68473d723e288330811c973e091344ca