### PR TITLE
Unify bootstrap layout for all forms

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,10 +1,18 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>{{ _('user_management') }}</h1>
-<form action="{{ url_for('create_user') }}" method="post" class="two-column">
-<p><input type="text" name="username" placeholder="Username" required></p>
-<p><input type="password" name="password" placeholder="Password" required></p>
-<p><button type="submit">Create User</button></p>
+<form action="{{ url_for('create_user') }}" method="post" class="row g-3 mb-3">
+    <div class="col-md-6">
+        <label class="form-label">Username</label>
+        <input type="text" name="username" class="form-control" required>
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Password</label>
+        <input type="password" name="password" class="form-control" required>
+    </div>
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Create User</button>
+    </div>
 </form>
 <table>
 <tr><th>User</th><th>Action</th></tr>

--- a/templates/edit_account.html
+++ b/templates/edit_account.html
@@ -1,13 +1,33 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Edit Account</h1>
-<form action="{{ url_for('update_account', account_id=account.id) }}" method="post" class="two-column">
-<p><input type="text" name="name" value="{{ account.name }}" required></p>
-<p><input type="text" name="industry" value="{{ account.industry }}"></p>
-<p><input type="email" name="email" value="{{ account.email }}"></p>
-<p><input type="text" name="phone" value="{{ account.phone }}"></p>
-<p><input type="text" name="address" value="{{ account.address }}"></p>
-<p><textarea name="notes">{{ account.notes }}</textarea></p>
-<p><button type="submit">Update</button></p>
+<form action="{{ url_for('update_account', account_id=account.id) }}" method="post" class="row g-3">
+    <div class="col-md-6">
+        <label class="form-label">Name *</label>
+        <input type="text" name="name" class="form-control" value="{{ account.name }}" required>
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Industry</label>
+        <input type="text" name="industry" class="form-control" value="{{ account.industry }}">
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Email</label>
+        <input type="email" name="email" class="form-control" value="{{ account.email }}">
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Phone</label>
+        <input type="text" name="phone" class="form-control" value="{{ account.phone }}">
+    </div>
+    <div class="col-12">
+        <label class="form-label">Address</label>
+        <input type="text" name="address" class="form-control" value="{{ account.address }}">
+    </div>
+    <div class="col-12">
+        <label class="form-label">Notes</label>
+        <textarea name="notes" class="form-control">{{ account.notes }}</textarea>
+    </div>
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Update</button>
+    </div>
 </form>
 {% endblock %}

--- a/templates/edit_contact.html
+++ b/templates/edit_contact.html
@@ -1,15 +1,30 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Edit Contact</h1>
-<form action="{{ url_for('update_contact', contact_id=contact.id) }}" method="post" class="two-column">
-<p><input type="text" name="name" value="{{ contact.name }}" required></p>
-<p><input type="email" name="email" value="{{ contact.email }}"></p>
-<p><input type="text" name="phone" value="{{ contact.phone }}"></p>
-<p><input type="text" name="title" value="{{ contact.title }}"></p>
-{% from 'macros.html' import lookup %}
-<p>
-    {{ lookup('account_id', accounts, 'name', contact.account_id) }}
-</p>
-<p><button type="submit">Update</button></p>
+<form action="{{ url_for('update_contact', contact_id=contact.id) }}" method="post" class="row g-3">
+    <div class="col-md-6">
+        <label class="form-label">Name *</label>
+        <input type="text" name="name" class="form-control" value="{{ contact.name }}" required>
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Email</label>
+        <input type="email" name="email" class="form-control" value="{{ contact.email }}">
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Phone</label>
+        <input type="text" name="phone" class="form-control" value="{{ contact.phone }}">
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Title</label>
+        <input type="text" name="title" class="form-control" value="{{ contact.title }}">
+    </div>
+    {% from 'macros.html' import lookup %}
+    <div class="col-md-6">
+        <label class="form-label">Account</label>
+        {{ lookup('account_id', accounts, 'name', contact.account_id) }}
+    </div>
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Update</button>
+    </div>
 </form>
 {% endblock %}

--- a/templates/edit_customer.html
+++ b/templates/edit_customer.html
@@ -1,11 +1,25 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Edit Customer</h1>
-<form action="{{ url_for('update_customer', customer_id=customer.id) }}" method="post">
-<p><input type="text" name="name" value="{{ customer.name }}" required></p>
-<p><input type="email" name="email" value="{{ customer.email }}"></p>
-<p><input type="text" name="phone" value="{{ customer.phone }}"></p>
-<p><textarea name="notes">{{ customer.notes }}</textarea></p>
-<p><button type="submit">Update</button></p>
+<form action="{{ url_for('update_customer', customer_id=customer.id) }}" method="post" class="row g-3">
+    <div class="col-md-6">
+        <label class="form-label">Name *</label>
+        <input type="text" name="name" class="form-control" value="{{ customer.name }}" required>
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Email</label>
+        <input type="email" name="email" class="form-control" value="{{ customer.email }}">
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Phone</label>
+        <input type="text" name="phone" class="form-control" value="{{ customer.phone }}">
+    </div>
+    <div class="col-12">
+        <label class="form-label">Notes</label>
+        <textarea name="notes" class="form-control">{{ customer.notes }}</textarea>
+    </div>
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Update</button>
+    </div>
 </form>
 {% endblock %}

--- a/templates/edit_deal.html
+++ b/templates/edit_deal.html
@@ -1,21 +1,34 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Edit Deal</h1>
-<form action="{{ url_for('update_deal', deal_id=deal.id) }}" method="post" class="two-column">
-<p><input type="text" name="name" value="{{ deal.name }}" required></p>
-<p><input type="number" step="0.01" name="amount" value="{{ deal.amount }}"></p>
-<p>
-    <select name="stage">
-        {% for s in stages %}
-            <option value="{{ s.value }}" {% if s.value == deal.stage %}selected{% endif %}>{{ s.value }}</option>
-        {% endfor %}
-    </select>
-</p>
-<p><input type="date" name="close_date" value="{{ deal.close_date }}"></p>
-{% from 'macros.html' import lookup %}
-<p>
-    {{ lookup('account_id', accounts, 'name', deal.account_id) }}
-</p>
-<p><button type="submit">Update</button></p>
+<form action="{{ url_for('update_deal', deal_id=deal.id) }}" method="post" class="row g-3">
+    <div class="col-md-6">
+        <label class="form-label">Name *</label>
+        <input type="text" name="name" class="form-control" value="{{ deal.name }}" required>
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Amount</label>
+        <input type="number" step="0.01" name="amount" class="form-control" value="{{ deal.amount }}">
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Stage</label>
+        <select name="stage" class="form-select">
+            {% for s in stages %}
+                <option value="{{ s.value }}" {% if s.value == deal.stage %}selected{% endif %}>{{ s.value }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Close Date</label>
+        <input type="date" name="close_date" class="form-control" value="{{ deal.close_date }}">
+    </div>
+    {% from 'macros.html' import lookup %}
+    <div class="col-md-6">
+        <label class="form-label">Account</label>
+        {{ lookup('account_id', accounts, 'name', deal.account_id) }}
+    </div>
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Update</button>
+    </div>
 </form>
 {% endblock %}

--- a/templates/edit_pricebook.html
+++ b/templates/edit_pricebook.html
@@ -1,9 +1,17 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Edit Pricebook</h1>
-<form action="{{ url_for('update_pricebook', pricebook_id=pricebook.id) }}" method="post" class="two-column">
-<p><input type="text" name="name" value="{{ pricebook.name }}" required></p>
-<p><textarea name="description">{{ pricebook.description }}</textarea></p>
-<p><button type="submit">Update</button></p>
+<form action="{{ url_for('update_pricebook', pricebook_id=pricebook.id) }}" method="post" class="row g-3">
+    <div class="col-md-6">
+        <label class="form-label">Name *</label>
+        <input type="text" name="name" class="form-control" value="{{ pricebook.name }}" required>
+    </div>
+    <div class="col-12">
+        <label class="form-label">Description</label>
+        <textarea name="description" class="form-control">{{ pricebook.description }}</textarea>
+    </div>
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Update</button>
+    </div>
 </form>
 {% endblock %}

--- a/templates/edit_pricebook_entry.html
+++ b/templates/edit_pricebook_entry.html
@@ -1,15 +1,22 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Edit Price Book Entry</h1>
-<form action="{{ url_for('update_pricebook_entry', entry_id=entry.id) }}" method="post">
-{% from 'macros.html' import lookup %}
-<p>
-    {{ lookup('product_id', products, 'name', entry.product_id) }}
-</p>
-<p>
-    {{ lookup('pricebook_id', pricebooks, 'name', entry.pricebook_id) }}
-</p>
-<p><input type="number" step="0.01" name="unit_price" value="{{ entry.unit_price }}"></p>
-<p><button type="submit">Update</button></p>
+<form action="{{ url_for('update_pricebook_entry', entry_id=entry.id) }}" method="post" class="row g-3">
+    {% from 'macros.html' import lookup %}
+    <div class="col-md-6">
+        <label class="form-label">Product</label>
+        {{ lookup('product_id', products, 'name', entry.product_id) }}
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Pricebook</label>
+        {{ lookup('pricebook_id', pricebooks, 'name', entry.pricebook_id) }}
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Unit Price</label>
+        <input type="number" step="0.01" name="unit_price" class="form-control" value="{{ entry.unit_price }}">
+    </div>
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Update</button>
+    </div>
 </form>
 {% endblock %}

--- a/templates/edit_product.html
+++ b/templates/edit_product.html
@@ -1,10 +1,21 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Edit Product</h1>
-<form action="{{ url_for('update_product', product_id=product.id) }}" method="post" class="two-column">
-<p><input type="text" name="name" value="{{ product.name }}" required></p>
-<p><input type="number" step="0.01" name="price" value="{{ product.price }}"></p>
-<p><textarea name="description">{{ product.description }}</textarea></p>
-<p><button type="submit">Update</button></p>
+<form action="{{ url_for('update_product', product_id=product.id) }}" method="post" class="row g-3">
+    <div class="col-md-6">
+        <label class="form-label">Name *</label>
+        <input type="text" name="name" class="form-control" value="{{ product.name }}" required>
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Price</label>
+        <input type="number" step="0.01" name="price" class="form-control" value="{{ product.price }}">
+    </div>
+    <div class="col-12">
+        <label class="form-label">Description</label>
+        <textarea name="description" class="form-control">{{ product.description }}</textarea>
+    </div>
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Update</button>
+    </div>
 </form>
 {% endblock %}

--- a/templates/edit_quote.html
+++ b/templates/edit_quote.html
@@ -1,13 +1,22 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Edit Quote</h1>
-<form action="{{ url_for('update_quote', quote_id=quote.id) }}" method="post" class="two-column">
-{% from 'macros.html' import lookup %}
-<p>
-    {{ lookup('deal_id', deals, 'name', quote.deal_id) }}
-</p>
-<p><input type="number" step="0.01" name="total" value="{{ quote.total }}"></p>
-<p><input type="date" name="expiration_date" value="{{ quote.expiration_date }}"></p>
-<p><button type="submit">Update</button></p>
+<form action="{{ url_for('update_quote', quote_id=quote.id) }}" method="post" class="row g-3">
+    {% from 'macros.html' import lookup %}
+    <div class="col-md-6">
+        <label class="form-label">Deal</label>
+        {{ lookup('deal_id', deals, 'name', quote.deal_id) }}
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Total</label>
+        <input type="number" step="0.01" name="total" class="form-control" value="{{ quote.total }}">
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Expiration</label>
+        <input type="date" name="expiration_date" class="form-control" value="{{ quote.expiration_date }}">
+    </div>
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Update</button>
+    </div>
 </form>
 {% endblock %}

--- a/templates/edit_quote_line_item.html
+++ b/templates/edit_quote_line_item.html
@@ -1,16 +1,26 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Edit Quote Line Item</h1>
-<form action="{{ url_for('update_quote_line_item', item_id=item.id) }}" method="post">
-{% from 'macros.html' import lookup %}
-<p>
-    {{ lookup('quote_id', quotes, '', item.quote_id, 'Quote ') }}
-</p>
-<p>
-    {{ lookup('product_id', products, 'name', item.product_id) }}
-</p>
-<p><input type="number" name="quantity" value="{{ item.quantity }}"></p>
-<p><input type="number" step="0.01" name="price" value="{{ item.price }}"></p>
-<p><button type="submit">Update</button></p>
+<form action="{{ url_for('update_quote_line_item', item_id=item.id) }}" method="post" class="row g-3">
+    {% from 'macros.html' import lookup %}
+    <div class="col-md-6">
+        <label class="form-label">Quote</label>
+        {{ lookup('quote_id', quotes, '', item.quote_id, 'Quote ') }}
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Product</label>
+        {{ lookup('product_id', products, 'name', item.product_id) }}
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Quantity</label>
+        <input type="number" name="quantity" class="form-control" value="{{ item.quantity }}">
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Price</label>
+        <input type="number" step="0.01" name="price" class="form-control" value="{{ item.price }}">
+    </div>
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Update</button>
+    </div>
 </form>
 {% endblock %}

--- a/templates/new_account.html
+++ b/templates/new_account.html
@@ -1,18 +1,34 @@
 {% extends 'base.html' %}
 {% block content %}
-    <div class="App">
-        <header class="App-header">
-            <h1>New Account</h1>
-            <form action="{{ url_for('create_account') }}" method="post" class="two-column">
-                <p><input type="text" name="name" placeholder="Name" required></p>
-                <p><input type="text" name="industry" placeholder="Industry"></p>
-                <p><input type="email" name="email" placeholder="Email"></p>
-                <p><input type="text" name="phone" placeholder="Phone"></p>
-                <p><input type="text" name="address" placeholder="Address"></p>
-                <p><textarea name="notes" placeholder="Notes"></textarea></p>
-                <p><button type="submit">Create</button></p>
-            </form>
-            <p><a class="App-link" href="{{ url_for('list_accounts') }}">Back</a></p>
-        </header>
+<h1>New Account</h1>
+<form action="{{ url_for('create_account') }}" method="post" class="row g-3">
+    <div class="col-md-6">
+        <label class="form-label">Name *</label>
+        <input type="text" name="name" class="form-control" required>
     </div>
+    <div class="col-md-6">
+        <label class="form-label">Industry</label>
+        <input type="text" name="industry" class="form-control">
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Email</label>
+        <input type="email" name="email" class="form-control">
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Phone</label>
+        <input type="text" name="phone" class="form-control">
+    </div>
+    <div class="col-12">
+        <label class="form-label">Address</label>
+        <input type="text" name="address" class="form-control">
+    </div>
+    <div class="col-12">
+        <label class="form-label">Notes</label>
+        <textarea name="notes" class="form-control"></textarea>
+    </div>
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Create</button>
+        <a class="btn btn-secondary" href="{{ url_for('list_accounts') }}">Back</a>
+    </div>
+</form>
 {% endblock %}

--- a/templates/new_contact.html
+++ b/templates/new_contact.html
@@ -1,20 +1,31 @@
 {% extends 'base.html' %}
 {% block content %}
-    <div class="App">
-        <header class="App-header">
-            <h1>New Contact</h1>
-            <form action="{{ url_for('create_contact') }}" method="post" class="two-column">
-                <p><input type="text" name="name" placeholder="Name" required></p>
-                <p><input type="email" name="email" placeholder="Email"></p>
-                <p><input type="text" name="phone" placeholder="Phone"></p>
-                <p><input type="text" name="title" placeholder="Title"></p>
-                {% from 'macros.html' import lookup %}
-                <p>
-                    {{ lookup('account_id', accounts, 'name') }}
-                </p>
-                <p><button type="submit">Create</button></p>
-            </form>
-            <p><a class="App-link" href="{{ url_for('list_contacts') }}">Back</a></p>
-        </header>
+<h1>New Contact</h1>
+<form action="{{ url_for('create_contact') }}" method="post" class="row g-3">
+    <div class="col-md-6">
+        <label class="form-label">Name *</label>
+        <input type="text" name="name" class="form-control" required>
     </div>
+    <div class="col-md-6">
+        <label class="form-label">Email</label>
+        <input type="email" name="email" class="form-control">
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Phone</label>
+        <input type="text" name="phone" class="form-control">
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Title</label>
+        <input type="text" name="title" class="form-control">
+    </div>
+    {% from 'macros.html' import lookup %}
+    <div class="col-md-6">
+        <label class="form-label">Account</label>
+        {{ lookup('account_id', accounts, 'name') }}
+    </div>
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Create</button>
+        <a class="btn btn-secondary" href="{{ url_for('list_contacts') }}">Back</a>
+    </div>
+</form>
 {% endblock %}

--- a/templates/new_customer.html
+++ b/templates/new_customer.html
@@ -1,16 +1,26 @@
 {% extends 'base.html' %}
 {% block content %}
-    <div class="App">
-        <header class="App-header">
-            <h1>New Customer</h1>
-            <form action="{{ url_for('create_customer') }}" method="post">
-                <p><input type="text" name="name" placeholder="Name" required></p>
-                <p><input type="email" name="email" placeholder="Email"></p>
-                <p><input type="text" name="phone" placeholder="Phone"></p>
-                <p><textarea name="notes" placeholder="Notes"></textarea></p>
-                <p><button type="submit">Create</button></p>
-            </form>
-            <p><a class="App-link" href="{{ url_for('list_customers') }}">Back</a></p>
-        </header>
+<h1>New Customer</h1>
+<form action="{{ url_for('create_customer') }}" method="post" class="row g-3">
+    <div class="col-md-6">
+        <label class="form-label">Name *</label>
+        <input type="text" name="name" class="form-control" required>
     </div>
+    <div class="col-md-6">
+        <label class="form-label">Email</label>
+        <input type="email" name="email" class="form-control">
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Phone</label>
+        <input type="text" name="phone" class="form-control">
+    </div>
+    <div class="col-12">
+        <label class="form-label">Notes</label>
+        <textarea name="notes" class="form-control"></textarea>
+    </div>
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Create</button>
+        <a class="btn btn-secondary" href="{{ url_for('list_customers') }}">Back</a>
+    </div>
+</form>
 {% endblock %}

--- a/templates/new_deal.html
+++ b/templates/new_deal.html
@@ -1,26 +1,35 @@
 {% extends 'base.html' %}
 {% block content %}
-    <div class="App">
-        <header class="App-header">
-            <h1>New Deal</h1>
-            <form action="{{ url_for('create_deal') }}" method="post" class="two-column">
-                <p><input type="text" name="name" placeholder="Name" required></p>
-                <p><input type="number" step="0.01" name="amount" placeholder="Amount"></p>
-                <p>
-                    <select name="stage">
-                        {% for s in stages %}
-                            <option value="{{ s.value }}">{{ s.value }}</option>
-                        {% endfor %}
-                    </select>
-                </p>
-                <p><input type="date" name="close_date"></p>
-                {% from 'macros.html' import lookup %}
-                <p>
-                    {{ lookup('account_id', accounts, 'name') }}
-                </p>
-                <p><button type="submit">Create</button></p>
-            </form>
-            <p><a class="App-link" href="{{ url_for('list_deals') }}">Back</a></p>
-        </header>
+<h1>New Deal</h1>
+<form action="{{ url_for('create_deal') }}" method="post" class="row g-3">
+    <div class="col-md-6">
+        <label class="form-label">Name *</label>
+        <input type="text" name="name" class="form-control" required>
     </div>
+    <div class="col-md-6">
+        <label class="form-label">Amount</label>
+        <input type="number" step="0.01" name="amount" class="form-control">
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Stage</label>
+        <select name="stage" class="form-select">
+            {% for s in stages %}
+                <option value="{{ s.value }}">{{ s.value }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Close Date</label>
+        <input type="date" name="close_date" class="form-control">
+    </div>
+    {% from 'macros.html' import lookup %}
+    <div class="col-md-6">
+        <label class="form-label">Account</label>
+        {{ lookup('account_id', accounts, 'name') }}
+    </div>
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Create</button>
+        <a class="btn btn-secondary" href="{{ url_for('list_deals') }}">Back</a>
+    </div>
+</form>
 {% endblock %}

--- a/templates/new_pricebook.html
+++ b/templates/new_pricebook.html
@@ -1,14 +1,18 @@
 {% extends 'base.html' %}
 {% block content %}
-    <div class="App">
-        <header class="App-header">
-            <h1>New Pricebook</h1>
-            <form action="{{ url_for('create_pricebook') }}" method="post" class="two-column">
-                <p><input type="text" name="name" placeholder="Name" required></p>
-                <p><textarea name="description" placeholder="Description"></textarea></p>
-                <p><button type="submit">Create</button></p>
-            </form>
-            <p><a class="App-link" href="{{ url_for('list_pricebooks') }}">Back</a></p>
-        </header>
+<h1>New Pricebook</h1>
+<form action="{{ url_for('create_pricebook') }}" method="post" class="row g-3">
+    <div class="col-md-6">
+        <label class="form-label">Name *</label>
+        <input type="text" name="name" class="form-control" required>
     </div>
+    <div class="col-12">
+        <label class="form-label">Description</label>
+        <textarea name="description" class="form-control"></textarea>
+    </div>
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Create</button>
+        <a class="btn btn-secondary" href="{{ url_for('list_pricebooks') }}">Back</a>
+    </div>
+</form>
 {% endblock %}

--- a/templates/new_pricebook_entry.html
+++ b/templates/new_pricebook_entry.html
@@ -1,20 +1,23 @@
 {% extends 'base.html' %}
 {% block content %}
-    <div class="App">
-        <header class="App-header">
-            <h1>New Price Book Entry</h1>
-            <form action="{{ url_for('create_pricebook_entry') }}" method="post">
-                {% from 'macros.html' import lookup %}
-                <p>
-                    {{ lookup('product_id', products, 'name') }}
-                </p>
-                <p>
-                    {{ lookup('pricebook_id', pricebooks, 'name') }}
-                </p>
-                <p><input type="number" step="0.01" name="unit_price" placeholder="Unit Price"></p>
-                <p><button type="submit">Create</button></p>
-            </form>
-            <p><a class="App-link" href="{{ url_for('list_pricebook_entries') }}">Back</a></p>
-        </header>
+<h1>New Price Book Entry</h1>
+<form action="{{ url_for('create_pricebook_entry') }}" method="post" class="row g-3">
+    {% from 'macros.html' import lookup %}
+    <div class="col-md-6">
+        <label class="form-label">Product</label>
+        {{ lookup('product_id', products, 'name') }}
     </div>
+    <div class="col-md-6">
+        <label class="form-label">Pricebook</label>
+        {{ lookup('pricebook_id', pricebooks, 'name') }}
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Unit Price</label>
+        <input type="number" step="0.01" name="unit_price" class="form-control">
+    </div>
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Create</button>
+        <a class="btn btn-secondary" href="{{ url_for('list_pricebook_entries') }}">Back</a>
+    </div>
+</form>
 {% endblock %}

--- a/templates/new_product.html
+++ b/templates/new_product.html
@@ -1,15 +1,22 @@
 {% extends 'base.html' %}
 {% block content %}
-    <div class="App">
-        <header class="App-header">
-            <h1>New Product</h1>
-            <form action="{{ url_for('create_product') }}" method="post" class="two-column">
-                <p><input type="text" name="name" placeholder="Name" required></p>
-                <p><input type="number" step="0.01" name="price" placeholder="Price"></p>
-                <p><textarea name="description" placeholder="Description"></textarea></p>
-                <p><button type="submit">Create</button></p>
-            </form>
-            <p><a class="App-link" href="{{ url_for('list_products') }}">Back</a></p>
-        </header>
+<h1>New Product</h1>
+<form action="{{ url_for('create_product') }}" method="post" class="row g-3">
+    <div class="col-md-6">
+        <label class="form-label">Name *</label>
+        <input type="text" name="name" class="form-control" required>
     </div>
+    <div class="col-md-6">
+        <label class="form-label">Price</label>
+        <input type="number" step="0.01" name="price" class="form-control">
+    </div>
+    <div class="col-12">
+        <label class="form-label">Description</label>
+        <textarea name="description" class="form-control"></textarea>
+    </div>
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Create</button>
+        <a class="btn btn-secondary" href="{{ url_for('list_products') }}">Back</a>
+    </div>
+</form>
 {% endblock %}

--- a/templates/new_quote.html
+++ b/templates/new_quote.html
@@ -1,18 +1,23 @@
 {% extends 'base.html' %}
 {% block content %}
-    <div class="App">
-        <header class="App-header">
-            <h1>New Quote</h1>
-            <form action="{{ url_for('create_quote') }}" method="post" class="two-column">
-                {% from 'macros.html' import lookup %}
-                <p>
-                    {{ lookup('deal_id', deals, 'name') }}
-                </p>
-                <p><input type="number" step="0.01" name="total" placeholder="Total"></p>
-                <p><input type="date" name="expiration_date" placeholder="Expiration"></p>
-                <p><button type="submit">Create</button></p>
-            </form>
-            <p><a class="App-link" href="{{ url_for('list_quotes') }}">Back</a></p>
-        </header>
+<h1>New Quote</h1>
+<form action="{{ url_for('create_quote') }}" method="post" class="row g-3">
+    {% from 'macros.html' import lookup %}
+    <div class="col-md-6">
+        <label class="form-label">Deal</label>
+        {{ lookup('deal_id', deals, 'name') }}
     </div>
+    <div class="col-md-6">
+        <label class="form-label">Total</label>
+        <input type="number" step="0.01" name="total" class="form-control">
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Expiration</label>
+        <input type="date" name="expiration_date" class="form-control">
+    </div>
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Create</button>
+        <a class="btn btn-secondary" href="{{ url_for('list_quotes') }}">Back</a>
+    </div>
+</form>
 {% endblock %}

--- a/templates/new_quote_line_item.html
+++ b/templates/new_quote_line_item.html
@@ -1,21 +1,27 @@
 {% extends 'base.html' %}
 {% block content %}
-    <div class="App">
-        <header class="App-header">
-            <h1>New Quote Line Item</h1>
-            <form action="{{ url_for('create_quote_line_item') }}" method="post">
-                {% from 'macros.html' import lookup %}
-                <p>
-                    {{ lookup('quote_id', quotes, '', '', 'Quote ') }}
-                </p>
-                <p>
-                    {{ lookup('product_id', products, 'name') }}
-                </p>
-                <p><input type="number" name="quantity" placeholder="Quantity" value="1"></p>
-                <p><input type="number" step="0.01" name="price" placeholder="Price"></p>
-                <p><button type="submit">Create</button></p>
-            </form>
-            <p><a class="App-link" href="{{ url_for('list_quote_line_items') }}">Back</a></p>
-        </header>
+<h1>New Quote Line Item</h1>
+<form action="{{ url_for('create_quote_line_item') }}" method="post" class="row g-3">
+    {% from 'macros.html' import lookup %}
+    <div class="col-md-6">
+        <label class="form-label">Quote</label>
+        {{ lookup('quote_id', quotes, '', '', 'Quote ') }}
     </div>
+    <div class="col-md-6">
+        <label class="form-label">Product</label>
+        {{ lookup('product_id', products, 'name') }}
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Quantity</label>
+        <input type="number" name="quantity" class="form-control" value="1">
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Price</label>
+        <input type="number" step="0.01" name="price" class="form-control">
+    </div>
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Create</button>
+        <a class="btn btn-secondary" href="{{ url_for('list_quote_line_items') }}">Back</a>
+    </div>
+</form>
 {% endblock %}

--- a/templates/new_task.html
+++ b/templates/new_task.html
@@ -1,18 +1,27 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>New Task</h1>
-<form action="{{ url_for('create_task') }}" method="post" class="two-column">
-<input type="hidden" name="model" value="{{ model }}">
-<input type="hidden" name="record_id" value="{{ record_id }}">
-<p><input type="text" name="description" placeholder="Description" required></p>
-<p><input type="date" name="due_date"></p>
-<p>
-    <select name="status">
-        {% for s in statuses %}
-            <option value="{{ s.value }}">{{ s.value }}</option>
-        {% endfor %}
-    </select>
-</p>
-<p><button type="submit">Create</button></p>
+<form action="{{ url_for('create_task') }}" method="post" class="row g-3">
+    <input type="hidden" name="model" value="{{ model }}">
+    <input type="hidden" name="record_id" value="{{ record_id }}">
+    <div class="col-md-6">
+        <label class="form-label">Description *</label>
+        <input type="text" name="description" class="form-control" required>
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Due Date</label>
+        <input type="date" name="due_date" class="form-control">
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">Status</label>
+        <select name="status" class="form-select">
+            {% for s in statuses %}
+                <option value="{{ s.value }}">{{ s.value }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Create</button>
+    </div>
 </form>
 {% endblock %}

--- a/templates/statuses.html
+++ b/templates/statuses.html
@@ -2,14 +2,18 @@
 {% block content %}
 <h1>{{ _('manage_statuses') }}</h1>
 <p><a class="App-link" href="{{ url_for('admin_overview') }}">{{ _('back_admin') }}</a></p>
-<form action="{{ url_for('create_status') }}" method="post" class="two-column">
-    <p>
-        <input type="text" name="model" placeholder="Model" required>
-    </p>
-    <p>
-        <input type="text" name="value" placeholder="Status" required>
-    </p>
-    <p><button type="submit">Add</button></p>
+<form action="{{ url_for('create_status') }}" method="post" class="row g-3 mb-3">
+    <div class="col-md-4">
+        <label class="form-label">Model</label>
+        <input type="text" name="model" class="form-control" required>
+    </div>
+    <div class="col-md-4">
+        <label class="form-label">Status</label>
+        <input type="text" name="value" class="form-control" required>
+    </div>
+    <div class="col-md-4 align-self-end">
+        <button type="submit" class="btn btn-primary">Add</button>
+    </div>
 </form>
 <table>
     <tr><th>Model</th><th>Status</th><th>Actions</th></tr>


### PR DESCRIPTION
## Summary
- switch all forms to use Bootstrap grid layout
- improve consistency in admin and status pages

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684741573c9883309c72bbd6fecd58a8