### PR TITLE
Add @ mention autocomplete to messages

### DIFF
--- a/app.py
+++ b/app.py
@@ -1335,6 +1335,17 @@ def api_get_record(model, record_id):
     return data
 
 
+@app.route("/api/users")
+@login_required
+def api_users():
+    q = request.args.get("q", "")
+    query = User.query
+    if q:
+        query = query.filter(User.username.ilike(f"%{q}%"))
+    users = query.all()
+    return {"users": [u.username for u in users]}
+
+
 with app.app_context():
     db.create_all()
     inspector = db.inspect(db.engine)

--- a/templates/messages_section.html
+++ b/templates/messages_section.html
@@ -19,7 +19,20 @@
 <script>
   if (window.ClassicEditor) {
     ClassicEditor.create(document.querySelector('#message-content'), {
-      toolbar: ['bold','italic','underline','bulletedList','numberedList']
+      toolbar: ['bold','italic','underline','bulletedList','numberedList'],
+      mention: {
+        feeds: [
+          {
+            marker: '@',
+            feed: query => {
+              return fetch('/api/users?q=' + encodeURIComponent(query))
+                .then(r => r.json())
+                .then(data => data.users);
+            },
+            minimumCharacters: 1
+          }
+        ]
+      }
     }).catch(e=>{});
   }
 </script>


### PR DESCRIPTION
## Summary
- enable user lookup in the message editor via CKEditor mention feed
- expose `/api/users` endpoint for searching usernames

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6847428efeb08330aa7223901637897f