### PR TITLE
Remove CKEditor and rely on custom textarea mention

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ from flask import (
     url_for,
     flash,
     session,
+    escape,
 )
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import (
@@ -1047,7 +1048,8 @@ def create_task():
 @app.route("/messages/create", methods=["POST"])
 @login_required
 def create_message():
-    content = request.form["content"]
+    content_raw = request.form["content"]
+    content = f"<p>{escape(content_raw)}</p>"
     model = request.form.get("model")
     record_id = request.form.get("record_id")
     message = Message(
@@ -1059,7 +1061,7 @@ def create_message():
     db.session.add(message)
     db.session.commit()
 
-    mentioned = set(re.findall(r"@(\w+)", content))
+    mentioned = set(re.findall(r"@(\w+)", content_raw))
     for username in mentioned:
         user = User.query.filter_by(username=username).first()
         if user:

--- a/static/main.js
+++ b/static/main.js
@@ -124,7 +124,5 @@ window.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    if (!window.ClassicEditor) {
-        document.querySelectorAll('textarea.mention-enabled').forEach(initMentions);
-    }
+    document.querySelectorAll('textarea.mention-enabled').forEach(initMentions);
 });

--- a/templates/messages_section.html
+++ b/templates/messages_section.html
@@ -15,24 +15,3 @@
     <textarea id="message-content" name="content" class="form-control mention-enabled" rows="3"></textarea>
     <button type="submit" class="btn btn-primary mt-2">Send</button>
 </form>
-<script src="https://cdn.jsdelivr.net/npm/@ckeditor/ckeditor5-build-classic@35.4.0/build/ckeditor.js"></script>
-<script>
-  if (window.ClassicEditor) {
-    ClassicEditor.create(document.querySelector('#message-content'), {
-      toolbar: ['bold','italic','underline','bulletedList','numberedList'],
-      mention: {
-        feeds: [
-          {
-            marker: '@',
-            feed: query => {
-              return fetch('/api/users?q=' + encodeURIComponent(query))
-                .then(r => r.json())
-                .then(data => data.users.map(u => '@' + u));
-            },
-            minimumCharacters: 0
-          }
-        ]
-      }
-    }).catch(e=>{});
-  }
-</script>


### PR DESCRIPTION
## Summary
- drop CKEditor from the message section
- sanitize and wrap new messages in `<p>` tags before saving
- always enable custom mention dropdown logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68474f25c6d483309a09da6e7133d869